### PR TITLE
Fix npm build script and add vitest config

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,10 @@
   },
   "scripts": {
     "dev": "tauri dev",
+    "build": "vite build",
     "vite-build": "vite build",
     "tauri": "tauri build",
+    "tauri-build": "tauri build",
     "preview": "vite preview",
     "check": "svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-check --tsconfig ./tsconfig.json --watch",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom'
+  }
+})


### PR DESCRIPTION
## Summary
- ensure `build` script exists in package.json for Makefile build target
- configure Vitest to use jsdom environment

## Testing
- `make build` *(fails: glib-2.0 pkg-config missing)*
- `npm run test:run` *(fails: several unit tests)*

------
https://chatgpt.com/codex/tasks/task_e_68514791c8008324ad6a247b1f8f7cdf