### PR TITLE
Phase 2: add component validation docs & ClipboardSync tests

### DIFF
--- a/.codex.json
+++ b/.codex.json
@@ -9,5 +9,8 @@
     "analyze": "bash scripts/analyze-and-report.sh",
     "init": "bash scripts/init-for-codex.sh",
     "test": "npm run test"
+  },
+  "phases": {
+    "2": "Komponenten validieren & vervollständigen"
   }
 }

--- a/docs/docs/components/ClipboardSync.md
+++ b/docs/docs/components/ClipboardSync.md
@@ -1,19 +1,28 @@
 # ClipboardSync
 
-Synchronises clipboard contents between host and client using Tauri IPC commands.
-
-## Events
-- `onSync(entry)` – fired when clipboard data is exchanged.
-- `onError(message)` – emitted when synchronization fails.
+Synchronizes clipboard content between host and client via Tauri IPC calls.
+This component listens for clipboard changes and forwards entries over an
+optional `WebRTCConnection`.
 
 ## Props
 
-| Name | Type | Description |
-| --- | --- | --- |
-| `pollInterval` | number | milliseconds between checks |
+| Name               | Type                              | Description                           |
+| ------------------ | --------------------------------- | ------------------------------------- |
+| `webrtcConnection` | `WebRTCConnection?`               | connection used to broadcast entries  |
+| `onSync`           | `(entry: ClipboardEntry) => void` | callback when a new entry was synced  |
+| `onError`          | `(msg: string) => void`           | reports initialization or sync errors |
 
-### Example
+## Events
+
+- `onSync(entry)` – fired when clipboard data was processed
+- `onError(message)` – emitted on any failure
+
+## Example
 
 ```tsx
-<ClipboardSync pollInterval={1000} onSync={(v) => console.log(v)} />
+<ClipboardSync onSync={(e) => console.log(e)} />
 ```
+
+### Teststatus
+
+Unit tests run with Vitest under `tests/unit/ClipboardSync.test.tsx`.

--- a/docs/docs/components/index.md
+++ b/docs/docs/components/index.md
@@ -2,6 +2,7 @@
 
 This section documents the main React components used in SmolDesk.
 
+- [Statusübersicht](./status.md)
 - [ConnectionManager](./ConnectionManager.md)
 - [RemoteScreen](./RemoteScreen.md)
 - [ClipboardSync](./ClipboardSync.md)

--- a/docs/docs/components/status.md
+++ b/docs/docs/components/status.md
@@ -1,0 +1,8 @@
+# Komponentenstatus
+
+| Komponente        | Vervollständigungsgrad       | Letzter Commit | Hinweise/Bugs |
+| ----------------- | ---------------------------- | -------------- | ------------- |
+| ClipboardSync     | Code ✅ / Tests ✅ / Doku ✅ | 55ac6c4        | -             |
+| ConnectionManager | Code ✅ / Tests ❌ / Doku ✅ | 3a8f4e9        | -             |
+| FileTransfer      | Code ✅ / Tests ❌ / Doku ✅ | b586d51        | -             |
+| RemoteScreen      | Code ✅ / Tests ❌ / Doku ✅ | b82c852        | -             |

--- a/scripts/validate-components.sh
+++ b/scripts/validate-components.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -e
+components=(ClipboardSync ConnectionManager FileTransfer RemoteScreen)
+status=0
+for comp in "${components[@]}"; do
+  [[ -f "src/components/${comp}.tsx" ]] || { echo "missing source for $comp"; status=1; }
+  if [[ ! -f "tests/unit/${comp}.test.tsx" && ! -f "tests/unit/${comp}.test.ts" ]]; then
+    echo "missing tests for $comp"; status=1;
+  fi
+  [[ -f "docs/docs/components/${comp}.md" ]] || { echo "missing docs for $comp"; status=1; }
+  [[ -f "src/components/${comp}.demo.tsx" ]] || { echo "missing demo for $comp"; status=1; }
+done
+exit $status

--- a/src/components/ClipboardSync.demo.tsx
+++ b/src/components/ClipboardSync.demo.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import ClipboardSync from "./ClipboardSync";
+
+export default function ClipboardSyncDemo() {
+  return (
+    <div style={{ width: 400 }}>
+      <ClipboardSync />
+    </div>
+  );
+}

--- a/tests/unit/ClipboardSync.test.tsx
+++ b/tests/unit/ClipboardSync.test.tsx
@@ -1,0 +1,27 @@
+import "@testing-library/jest-dom";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import ClipboardSync from "../../src/components/ClipboardSync";
+import { invoke } from "@tauri-apps/api/tauri";
+import { Mock } from "vitest";
+
+vi.mock("../../src/utils/webrtc", () => ({
+  WebRTCConnection: class {},
+}));
+
+describe("ClipboardSync component", () => {
+  it("renders and toggles sync", async () => {
+    const mockInvoke = invoke as Mock;
+    mockInvoke.mockResolvedValueOnce("x11");
+    mockInvoke.mockResolvedValueOnce(true);
+    mockInvoke.mockResolvedValueOnce([]);
+
+    render(<ClipboardSync />);
+    await waitFor(() =>
+      expect(screen.getByText("Clipboard Sync")).toBeInTheDocument(),
+    );
+
+    const toggle = await screen.findByRole("button", { name: /disable/i });
+    fireEvent.click(toggle);
+    expect(invoke).toHaveBeenCalledWith("stop_clipboard_monitoring");
+  });
+});


### PR DESCRIPTION
## Summary
- document component status and update components index
- create validation script for components
- add demo and unit test for `ClipboardSync`
- expand ClipboardSync documentation
- update Codex phases

## Testing
- `bash scripts/validate-components.sh`
- `npm run test:run`

------
https://chatgpt.com/codex/tasks/task_e_68518120ebe88324a7400492a1aec769