### PR TITLE
Setup Codex agent docs and GitHub CLI

### DIFF
--- a/.codex.json
+++ b/.codex.json
@@ -1,6 +1,10 @@
 {
   "project": "SmolDesk",
-  "agents": ["Codex", "OpenHands", "TestRunner"],
+  "agents": [
+    "Codex",
+    "OpenHands",
+    "TestRunner"
+  ],
   "entrypoints": [
     "AGENTS.md",
     "docs/docs/development/plan.md"
@@ -17,5 +21,10 @@
     "4": "IPC und E2E Tests",
     "phase4": "complete",
     "phase5": "Komponentenvalidierung & visuelle Regression in Storybook"
-  }
+  },
+  "repo": "github.com/EcoSphereNetwork/SmolDesk",
+  "defaultBranch": "main",
+  "mergeStrategy": "squash",
+  "issueOnConflict": true,
+  "agentMode": "autonomous"
 }

--- a/.github/CODEX.md
+++ b/.github/CODEX.md
@@ -1,0 +1,6 @@
+# 🤖 Codex Guidelines
+
+- PRs only merge if `mergeable_state` is clean.
+- Resolve and document conflicts.
+- Create automatic issues when merges fail.
+- `.codex.json` configures agent behavior.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,17 @@ SmolDesk is a WebRTC based remote desktop tool for Linux. This guide allows LLM 
 - Update or create tests with any code change.
 - Write documentation to `docs/` when new features are added.
 
+## Agent Types and Responsibilities
+This project defines multiple autonomous agents. Each agent acts within a
+specific scope:
+
+- **Codex** – general repository automation, merges and conflict resolution.
+- **OpenHands** – parses documentation and lints prose.
+- **TestRunner** – runs the available test suites and reports coverage.
+
+An overview of all agents and their lifecycle is available in
+`docs/docs/agents/agent-types.md` and `docs/docs/agents/agent-life-cycle.md`.
+
 
 
 

--- a/AGENTS_DEV_GUIDE.md
+++ b/AGENTS_DEV_GUIDE.md
@@ -11,3 +11,4 @@ This guide explains how to extend SmolDesk using LLM driven agents.
 1. Create a description under `docs/docs/agents/`.
 2. Provide a script or entrypoint if the agent requires one.
 3. Update `.codex.json` with default actions.
+4. Reference new agent files in AGENTS.md so all agents follow the same lifecycle.

--- a/README.md
+++ b/README.md
@@ -262,6 +262,12 @@ Wir freuen uns über Beiträge! Bitte lesen Sie unseren [Contributing Guide](CON
 - [Discord Community][discord-url]
 - [Documentation][docs-url]
 
+## AI-gestützte Entwicklung
+
+Dieses Repository ist vorbereitet für autonome GitHub-Agenten (z. B. Codex).
+Siehe [AGENTS.md](./AGENTS.md) und
+[docs/docs/agents/README.md](./docs/docs/agents/README.md).
+
 ## 📄 License
 
 Verteilt unter der MIT-Lizenz. Siehe [LICENSE](LICENSE) für weitere Informationen.

--- a/docs/docs/agents/README.md
+++ b/docs/docs/agents/README.md
@@ -11,3 +11,5 @@ Each agent has a dedicated entry in `.codex.json` with default commands.
 Agents collaborate by creating issues and pull requests for each development phase.
 
 Agents follow the workflow described in `AGENTS.md`.
+
+See [agent-types.md](./agent-types.md) for a list of agent categories and [agent-life-cycle.md](./agent-life-cycle.md) for the workflow.

--- a/docs/docs/agents/agent-api-integration.md
+++ b/docs/docs/agents/agent-api-integration.md
@@ -1,0 +1,3 @@
+# Agent API Integration
+
+Agents interact with GitHub via the `gh` CLI or direct REST/GraphQL calls when needed.

--- a/docs/docs/agents/agent-decision-models.md
+++ b/docs/docs/agents/agent-decision-models.md
@@ -1,0 +1,4 @@
+# Agent Decision Models
+
+Codex evaluates mergeability and test results before applying changes.
+Agents use repository metadata and `.codex.json` settings to choose actions.

--- a/docs/docs/agents/agent-life-cycle.md
+++ b/docs/docs/agents/agent-life-cycle.md
@@ -1,0 +1,6 @@
+# Agent Life Cycle
+
+1. **Start** – analyze repository and plan actions.
+2. **Pull Request** – propose changes via PRs.
+3. **CI** – run automated checks and tests.
+4. **Deploy** – merge to main and release.

--- a/docs/docs/agents/agent-safety.md
+++ b/docs/docs/agents/agent-safety.md
@@ -1,0 +1,4 @@
+# Agent Safety
+
+- Document failures and create issues automatically.
+- Run tests after every change to avoid regressions.

--- a/docs/docs/agents/agent-types.md
+++ b/docs/docs/agents/agent-types.md
@@ -1,0 +1,5 @@
+# Agent Types
+
+- **Codex**: coordinates repository tasks and merges pull requests.
+- **OpenHands**: maintains documentation consistency.
+- **Governance**: enforces policies and oversees releases.

--- a/docs/docs/development/plan.md
+++ b/docs/docs/development/plan.md
@@ -40,3 +40,4 @@ Preparation for the next stage is outlined in the [Phase 4 Overview](../testing/
 Results are summarized in the [Phase 4 Report](./phase-4-report.md).
 The next step is defined in the [Phase 5 Overview](./phase-5-overview.md).
 See the [Playwright guide](../testing/playwright.md) for running E2E tests.
+\nSee [agent phases](../agents/agent-life-cycle.md) for the automated workflow.

--- a/docs/docs/testing/ci-overview.md
+++ b/docs/docs/testing/ci-overview.md
@@ -24,3 +24,4 @@ CI runs locally for developers and remotely on pull requests. Matrix jobs handle
 - **Remote**: komplette CI in GitHub Actions für Pull Requests und Merges
 
 See [Phase 3 Report](../development/phase-3-report.md) for the initial CI implementation.
+\nCI jobs may be triggered by agents as described in [../agents/README.md](../agents/README.md).

--- a/scripts/codex-create-issue.sh
+++ b/scripts/codex-create-issue.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# usage: ./codex-create-issue.sh "Title" "Body"
+
+gh issue create --title "$1" --body "$2" --label "conflict"


### PR DESCRIPTION
## Summary
- add `.github/CODEX.md` with basic agent rules
- create `codex-create-issue.sh` helper
- expand `AGENTS.md` with agent types
- update `AGENTS_DEV_GUIDE.md` and docs
- reference agents in README and CI docs
- update `.codex.json` with repo settings
- fix repo path in codex config

## Testing
- `npm test` *(fails: vitest not found)*
- `cargo test` *(fails: could not find `Cargo.toml`)*

------
https://chatgpt.com/codex/tasks/task_e_68518ff370588324af1f3edef232d856