### PR TITLE
Setup Codex agent docs and GitHub CLI

### DIFF
--- a/.codex.json
+++ b/.codex.json
@@ -1,6 +1,10 @@
 {
   "project": "SmolDesk",
-  "agents": ["Codex", "OpenHands", "TestRunner"],
+  "agents": [
+    "Codex",
+    "OpenHands",
+    "TestRunner"
+  ],
   "entrypoints": [
     "AGENTS.md",
     "docs/docs/development/plan.md"
@@ -17,5 +21,10 @@
     "4": "IPC und E2E Tests",
     "phase4": "complete",
     "phase5": "Komponentenvalidierung & visuelle Regression in Storybook"
-  }
+  },
+  "repo": "github.com/EcoSphereNetwork/SmolDesk",
+  "defaultBranch": "main",
+  "mergeStrategy": "squash",
+  "issueOnConflict": true,
+  "agentMode": "autonomous"
 }

--- a/.github/CODEX.md
+++ b/.github/CODEX.md
@@ -1,0 +1,6 @@
+# 🤖 Codex Guidelines
+
+- PRs only merge if `mergeable_state` is clean.
+- Resolve and document conflicts.
+- Create automatic issues when merges fail.
+- `.codex.json` configures agent behavior.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,17 @@ SmolDesk is a WebRTC based remote desktop tool for Linux. This guide allows LLM 
 - Update or create tests with any code change.
 - Write documentation to `docs/` when new features are added.
 
+## Agent Types and Responsibilities
+This project defines multiple autonomous agents. Each agent acts within a
+specific scope:
+
+- **Codex** – general repository automation, merges and conflict resolution.
+- **OpenHands** – parses documentation and lints prose.
+- **TestRunner** – runs the available test suites and reports coverage.
+
+An overview of all agents and their lifecycle is available in
+`docs/docs/agents/agent-types.md` and `docs/docs/agents/agent-life-cycle.md`.
+
 
 
 

--- a/AGENTS_DEV_GUIDE.md
+++ b/AGENTS_DEV_GUIDE.md
@@ -11,3 +11,4 @@ This guide explains how to extend SmolDesk using LLM driven agents.
 1. Create a description under `docs/docs/agents/`.
 2. Provide a script or entrypoint if the agent requires one.
 3. Update `.codex.json` with default actions.
+4. Reference new agent files in AGENTS.md so all agents follow the same lifecycle.

--- a/Deployment&Sicherheit.md
+++ b/Deployment&Sicherheit.md
@@ -19,7 +19,7 @@ Description: WebRTC-based Remote Desktop for Linux
  SmolDesk is a modern remote desktop solution that provides
  low-latency screen sharing using WebRTC technology.
  Supports both X11 and Wayland display servers.
-Homepage: https://github.com/SmolDesk/SmolDesk
+Homepage: https://github.com/EcoSphereNetwork/SmolDesk
 ```
 
 **Datei: `packaging/debian/DEBIAN/postinst`**
@@ -130,7 +130,7 @@ Release:        1%{?dist}
 Summary:        WebRTC-based Remote Desktop for Linux
 
 License:        MIT
-URL:            https://github.com/SmolDesk/SmolDesk
+URL:            https://github.com/EcoSphereNetwork/SmolDesk
 Source0:        %{name}-%{version}.tar.gz
 
 BuildRequires:  nodejs >= 16
@@ -277,7 +277,7 @@ AppDir:
 AppImage:
   arch: x86_64
   file_name-template: SmolDesk-{{version}}-{{arch}}.AppImage
-  update-information: zsync|https://github.com/SmolDesk/SmolDesk/releases/latest/download/SmolDesk-latest-x86_64.AppImage.zsync
+  update-information: zsync|https://github.com/EcoSphereNetwork/SmolDesk/releases/latest/download/SmolDesk-latest-x86_64.AppImage.zsync
 ```
 
 #### 1.4 Flatpak Manifest
@@ -478,19 +478,19 @@ jobs:
           
           **Debian/Ubuntu (.deb):**
           ```bash
-          wget https://github.com/SmolDesk/SmolDesk/releases/download/${{ github.ref_name }}/smoldesk_1.0.0_amd64.deb
+          wget https://github.com/EcoSphereNetwork/SmolDesk/releases/download/${{ github.ref_name }}/smoldesk_1.0.0_amd64.deb
           sudo apt install ./smoldesk_1.0.0_amd64.deb
           ```
           
           **Fedora/RHEL (.rpm):**
           ```bash
-          wget https://github.com/SmolDesk/SmolDesk/releases/download/${{ github.ref_name }}/smoldesk-1.0.0-1.x86_64.rpm
+          wget https://github.com/EcoSphereNetwork/SmolDesk/releases/download/${{ github.ref_name }}/smoldesk-1.0.0-1.x86_64.rpm
           sudo dnf install ./smoldesk-1.0.0-1.x86_64.rpm
           ```
           
           **AppImage (Universal):**
           ```bash
-          wget https://github.com/SmolDesk/SmolDesk/releases/download/${{ github.ref_name }}/SmolDesk-1.0.0-x86_64.AppImage
+          wget https://github.com/EcoSphereNetwork/SmolDesk/releases/download/${{ github.ref_name }}/SmolDesk-1.0.0-x86_64.AppImage
           chmod +x SmolDesk-1.0.0-x86_64.AppImage
           ./SmolDesk-1.0.0-x86_64.AppImage
           ```
@@ -649,7 +649,7 @@ echo "RPM package created: $PACKAGE_DIR/smoldesk-$VERSION-1.$ARCH.rpm"
 ### Debian/Ubuntu
 ```bash
 # Download der neuesten Version
-wget https://github.com/SmolDesk/SmolDesk/releases/latest/download/smoldesk_1.0.0_amd64.deb
+wget https://github.com/EcoSphereNetwork/SmolDesk/releases/latest/download/smoldesk_1.0.0_amd64.deb
 
 # Installation
 sudo apt install ./smoldesk_1.0.0_amd64.deb
@@ -658,7 +658,7 @@ sudo apt install ./smoldesk_1.0.0_amd64.deb
 ### Fedora/RHEL/openSUSE
 ```bash
 # Download der neuesten Version
-wget https://github.com/SmolDesk/SmolDesk/releases/latest/download/smoldesk-1.0.0-1.x86_64.rpm
+wget https://github.com/EcoSphereNetwork/SmolDesk/releases/latest/download/smoldesk-1.0.0-1.x86_64.rpm
 
 # Installation
 sudo dnf install ./smoldesk-1.0.0-1.x86_64.rpm
@@ -669,7 +669,7 @@ sudo zypper install ./smoldesk-1.0.0-1.x86_64.rpm
 ### AppImage (Universal)
 ```bash
 # Download und ausführbar machen
-wget https://github.com/SmolDesk/SmolDesk/releases/latest/download/SmolDesk-1.0.0-x86_64.AppImage
+wget https://github.com/EcoSphereNetwork/SmolDesk/releases/latest/download/SmolDesk-1.0.0-x86_64.AppImage
 chmod +x SmolDesk-1.0.0-x86_64.AppImage
 
 # Starten
@@ -679,7 +679,7 @@ chmod +x SmolDesk-1.0.0-x86_64.AppImage
 ### Flatpak
 ```bash
 # Download und Installation
-wget https://github.com/SmolDesk/SmolDesk/releases/latest/download/SmolDesk.flatpak
+wget https://github.com/EcoSphereNetwork/SmolDesk/releases/latest/download/SmolDesk.flatpak
 flatpak install SmolDesk.flatpak
 
 # Starten
@@ -890,8 +890,8 @@ Keyframe Interval: 60
 ### Support
 
 Bei Problemen können Sie:
-1. Das [GitHub Issue Tracker](https://github.com/SmolDesk/SmolDesk/issues) nutzen
-2. Die [Diskussionen](https://github.com/SmolDesk/SmolDesk/discussions) durchsuchen
+1. Das [GitHub Issue Tracker](https://github.com/EcoSphereNetwork/SmolDesk/issues) nutzen
+2. Die [Diskussionen](https://github.com/EcoSphereNetwork/SmolDesk/discussions) durchsuchen
 3. Die [Community](https://discord.gg/smoldesk) im Discord kontaktieren
 
 **Bevor Sie einen Bug-Report erstellen:**

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@
   [![Documentation][docs-shield]][docs-url]
   [![Project Credits][credits-shield]][credits-url]
 
-  [Start Documentation](https://github.com/SmolDesk/SmolDesk/blob/main/docs/README.md) •
-  [Report Bug](https://github.com/SmolDesk/SmolDesk/issues) •
-  [Request Feature](https://github.com/SmolDesk/SmolDesk/issues)
+  [Start Documentation](https://github.com/EcoSphereNetwork/SmolDesk/blob/main/docs/README.md) •
+  [Report Bug](https://github.com/EcoSphereNetwork/SmolDesk/issues) •
+  [Request Feature](https://github.com/EcoSphereNetwork/SmolDesk/issues)
 </div>
 
 ## 📋 Table of Contents
@@ -95,15 +95,15 @@ Für die Tauri-spezifischen Libraries steht zusätzlich `scripts/install-tauri-d
 1. **Binärdateien herunterladen**
    ```bash
    # Für Debian/Ubuntu-basierte Systeme
-   curl -L https://github.com/SmolDesk/SmolDesk/releases/latest/download/smoldesk_amd64.deb -o smoldesk.deb
+   curl -L https://github.com/EcoSphereNetwork/SmolDesk/releases/latest/download/smoldesk_amd64.deb -o smoldesk.deb
    sudo apt install ./smoldesk.deb
    
    # Für Fedora/RHEL-basierte Systeme
-   curl -L https://github.com/SmolDesk/SmolDesk/releases/latest/download/smoldesk.rpm -o smoldesk.rpm
+   curl -L https://github.com/EcoSphereNetwork/SmolDesk/releases/latest/download/smoldesk.rpm -o smoldesk.rpm
    sudo dnf install ./smoldesk.rpm
    
    # Distribution-unabhängig (AppImage)
-   curl -L https://github.com/SmolDesk/SmolDesk/releases/latest/download/SmolDesk.AppImage -o SmolDesk.AppImage
+   curl -L https://github.com/EcoSphereNetwork/SmolDesk/releases/latest/download/SmolDesk.AppImage -o SmolDesk.AppImage
    chmod +x SmolDesk.AppImage
    ```
 
@@ -145,7 +145,7 @@ SmolDesk/
 ### Entwicklungsumgebung einrichten
 1. Repository klonen:
    ```bash
-   git clone https://github.com/SmolDesk/SmolDesk.git
+   git clone https://github.com/EcoSphereNetwork/SmolDesk.git
    cd SmolDesk
    # GitHub-Remote setzen falls nicht vorhanden
    git remote get-url origin >/dev/null 2>&1 || \
@@ -257,10 +257,16 @@ Wir freuen uns über Beiträge! Bitte lesen Sie unseren [Contributing Guide](CON
 
 ## 💬 Support
 
-- [Issue Tracker](https://github.com/SmolDesk/SmolDesk/issues)
-- [Discussions](https://github.com/SmolDesk/SmolDesk/discussions)
+- [Issue Tracker](https://github.com/EcoSphereNetwork/SmolDesk/issues)
+- [Discussions](https://github.com/EcoSphereNetwork/SmolDesk/discussions)
 - [Discord Community][discord-url]
 - [Documentation][docs-url]
+
+## AI-gestützte Entwicklung
+
+Dieses Repository ist vorbereitet für autonome GitHub-Agenten (z. B. Codex).
+Siehe [AGENTS.md](./AGENTS.md) und
+[docs/docs/agents/README.md](./docs/docs/agents/README.md).
 
 ## 📄 License
 
@@ -277,19 +283,19 @@ Verteilt unter der MIT-Lizenz. Siehe [LICENSE](LICENSE) für weitere Information
 </div>
 
 <!-- MARKDOWN LINKS & IMAGES -->
-[contributors-shield]: https://img.shields.io/github/contributors/SmolDesk/SmolDesk?style=for-the-badge&color=blue
-[contributors-url]: https://github.com/SmolDesk/SmolDesk/graphs/contributors
-[stars-shield]: https://img.shields.io/github/stars/SmolDesk/SmolDesk?style=for-the-badge&color=blue
-[stars-url]: https://github.com/SmolDesk/SmolDesk/stargazers
-[coverage-shield]: https://img.shields.io/codecov/c/github/SmolDesk/SmolDesk?style=for-the-badge&color=blue
-[coverage-url]: https://codecov.io/github/SmolDesk/SmolDesk
-[license-shield]: https://img.shields.io/github/license/SmolDesk/SmolDesk?style=for-the-badge&color=blue
-[license-url]: https://github.com/SmolDesk/SmolDesk/blob/main/LICENSE
+[contributors-shield]: https://img.shields.io/github/contributors/EcoSphereNetwork/SmolDesk?style=for-the-badge&color=blue
+[contributors-url]: https://github.com/EcoSphereNetwork/SmolDesk/graphs/contributors
+[stars-shield]: https://img.shields.io/github/stars/EcoSphereNetwork/SmolDesk?style=for-the-badge&color=blue
+[stars-url]: https://github.com/EcoSphereNetwork/SmolDesk/stargazers
+[coverage-shield]: https://img.shields.io/codecov/c/github/EcoSphereNetwork/SmolDesk?style=for-the-badge&color=blue
+[coverage-url]: https://codecov.io/github/EcoSphereNetwork/SmolDesk
+[license-shield]: https://img.shields.io/github/license/EcoSphereNetwork/SmolDesk?style=for-the-badge&color=blue
+[license-url]: https://github.com/EcoSphereNetwork/SmolDesk/blob/main/LICENSE
 [discord-shield]: https://img.shields.io/badge/Discord-Join%20Us-purple?logo=discord&logoColor=white&style=for-the-badge
 [discord-url]: https://discord.gg/smoldesk
 [docs-shield]: https://img.shields.io/badge/Documentation-000?logo=googledocs&logoColor=FFE165&style=for-the-badge
-[docs-url]: https://github.com/SmolDesk/SmolDesk/wiki
+[docs-url]: https://github.com/EcoSphereNetwork/SmolDesk/wiki
 [credits-shield]: https://img.shields.io/badge/Project-Credits-blue?style=for-the-badge&color=FFE165&logo=github&logoColor=white
-[credits-url]: https://github.com/SmolDesk/SmolDesk/blob/main/CREDITS.md
+[credits-url]: https://github.com/EcoSphereNetwork/SmolDesk/blob/main/CREDITS.md
 [activity-graph]: https://repobeats.axiom.co/api/embed/placeholder-for-smoldesk-activity-graph.svg
 [activity-url]: https://repobeats.axiom.co

--- a/docs/docs/SmolDesk/README.md
+++ b/docs/docs/SmolDesk/README.md
@@ -68,9 +68,9 @@ In dieser Dokumentation werden folgende Konventionen verwendet:
 
 Wenn Sie Fragen haben, die in dieser Dokumentation nicht beantwortet werden:
 
-- Besuchen Sie die [GitHub Discussions](https://github.com/SmolDesk/SmolDesk/discussions)
+- Besuchen Sie die [GitHub Discussions](https://github.com/EcoSphereNetwork/SmolDesk/discussions)
 - Treten Sie unserem [Discord-Server](https://discord.gg/smoldesk) bei
-- Öffnen Sie ein [Support-Ticket](https://github.com/SmolDesk/SmolDesk/issues/new?template=support_request.md)
+- Öffnen Sie ein [Support-Ticket](https://github.com/EcoSphereNetwork/SmolDesk/issues/new?template=support_request.md)
 
 ## Entwicklungsstatus
 

--- a/docs/docs/SmolDesk/user/USER_GUIDE.md
+++ b/docs/docs/SmolDesk/user/USER_GUIDE.md
@@ -13,7 +13,7 @@
 ### Debian/Ubuntu
 ```bash
 # Download der neuesten Version
-wget https://github.com/SmolDesk/SmolDesk/releases/latest/download/smoldesk_1.0.0_amd64.deb
+wget https://github.com/EcoSphereNetwork/SmolDesk/releases/latest/download/smoldesk_1.0.0_amd64.deb
 
 # Installation
 sudo apt install ./smoldesk_1.0.0_amd64.deb
@@ -22,7 +22,7 @@ sudo apt install ./smoldesk_1.0.0_amd64.deb
 ### Fedora/RHEL/openSUSE
 ```bash
 # Download der neuesten Version
-wget https://github.com/SmolDesk/SmolDesk/releases/latest/download/smoldesk-1.0.0-1.x86_64.rpm
+wget https://github.com/EcoSphereNetwork/SmolDesk/releases/latest/download/smoldesk-1.0.0-1.x86_64.rpm
 
 # Installation
 sudo dnf install ./smoldesk-1.0.0-1.x86_64.rpm
@@ -33,7 +33,7 @@ sudo zypper install ./smoldesk-1.0.0-1.x86_64.rpm
 ### AppImage (Universal)
 ```bash
 # Download und ausführbar machen
-wget https://github.com/SmolDesk/SmolDesk/releases/latest/download/SmolDesk-1.0.0-x86_64.AppImage
+wget https://github.com/EcoSphereNetwork/SmolDesk/releases/latest/download/SmolDesk-1.0.0-x86_64.AppImage
 chmod +x SmolDesk-1.0.0-x86_64.AppImage
 
 # Starten
@@ -43,7 +43,7 @@ chmod +x SmolDesk-1.0.0-x86_64.AppImage
 ### Flatpak
 ```bash
 # Download und Installation
-wget https://github.com/SmolDesk/SmolDesk/releases/latest/download/SmolDesk.flatpak
+wget https://github.com/EcoSphereNetwork/SmolDesk/releases/latest/download/SmolDesk.flatpak
 flatpak install SmolDesk.flatpak
 
 # Starten
@@ -254,8 +254,8 @@ Keyframe Interval: 60
 ### Support
 
 Bei Problemen können Sie:
-1. Das [GitHub Issue Tracker](https://github.com/SmolDesk/SmolDesk/issues) nutzen
-2. Die [Diskussionen](https://github.com/SmolDesk/SmolDesk/discussions) durchsuchen
+1. Das [GitHub Issue Tracker](https://github.com/EcoSphereNetwork/SmolDesk/issues) nutzen
+2. Die [Diskussionen](https://github.com/EcoSphereNetwork/SmolDesk/discussions) durchsuchen
 3. Die [Community](https://discord.gg/smoldesk) im Discord kontaktieren
 
 **Bevor Sie einen Bug-Report erstellen:**

--- a/docs/docs/agents/README.md
+++ b/docs/docs/agents/README.md
@@ -11,3 +11,5 @@ Each agent has a dedicated entry in `.codex.json` with default commands.
 Agents collaborate by creating issues and pull requests for each development phase.
 
 Agents follow the workflow described in `AGENTS.md`.
+
+See [agent-types.md](./agent-types.md) for a list of agent categories and [agent-life-cycle.md](./agent-life-cycle.md) for the workflow.

--- a/docs/docs/agents/agent-api-integration.md
+++ b/docs/docs/agents/agent-api-integration.md
@@ -1,0 +1,3 @@
+# Agent API Integration
+
+Agents interact with GitHub via the `gh` CLI or direct REST/GraphQL calls when needed.

--- a/docs/docs/agents/agent-decision-models.md
+++ b/docs/docs/agents/agent-decision-models.md
@@ -1,0 +1,4 @@
+# Agent Decision Models
+
+Codex evaluates mergeability and test results before applying changes.
+Agents use repository metadata and `.codex.json` settings to choose actions.

--- a/docs/docs/agents/agent-life-cycle.md
+++ b/docs/docs/agents/agent-life-cycle.md
@@ -1,0 +1,6 @@
+# Agent Life Cycle
+
+1. **Start** – analyze repository and plan actions.
+2. **Pull Request** – propose changes via PRs.
+3. **CI** – run automated checks and tests.
+4. **Deploy** – merge to main and release.

--- a/docs/docs/agents/agent-safety.md
+++ b/docs/docs/agents/agent-safety.md
@@ -1,0 +1,4 @@
+# Agent Safety
+
+- Document failures and create issues automatically.
+- Run tests after every change to avoid regressions.

--- a/docs/docs/agents/agent-types.md
+++ b/docs/docs/agents/agent-types.md
@@ -1,0 +1,5 @@
+# Agent Types
+
+- **Codex**: coordinates repository tasks and merges pull requests.
+- **OpenHands**: maintains documentation consistency.
+- **Governance**: enforces policies and oversees releases.

--- a/docs/docs/development/plan.md
+++ b/docs/docs/development/plan.md
@@ -40,3 +40,4 @@ Preparation for the next stage is outlined in the [Phase 4 Overview](../testing/
 Results are summarized in the [Phase 4 Report](./phase-4-report.md).
 The next step is defined in the [Phase 5 Overview](./phase-5-overview.md).
 See the [Playwright guide](../testing/playwright.md) for running E2E tests.
+\nSee [agent phases](../agents/agent-life-cycle.md) for the automated workflow.

--- a/docs/docs/testing/ci-overview.md
+++ b/docs/docs/testing/ci-overview.md
@@ -24,3 +24,4 @@ CI runs locally for developers and remotely on pull requests. Matrix jobs handle
 - **Remote**: komplette CI in GitHub Actions für Pull Requests und Merges
 
 See [Phase 3 Report](../development/phase-3-report.md) for the initial CI implementation.
+\nCI jobs may be triggered by agents as described in [../agents/README.md](../agents/README.md).

--- a/packaging/appimage/AppImageBuilder.yml
+++ b/packaging/appimage/AppImageBuilder.yml
@@ -63,5 +63,5 @@ AppDir:
 AppImage:
   arch: x86_64
   file_name-template: SmolDesk-{{version}}-{{arch}}.AppImage
-  update-information: zsync|https://github.com/SmolDesk/SmolDesk/releases/latest/download/SmolDesk-latest-x86_64.AppImage.zsync
+  update-information: zsync|https://github.com/EcoSphereNetwork/SmolDesk/releases/latest/download/SmolDesk-latest-x86_64.AppImage.zsync
 

--- a/packaging/rpm/smoldesk.spec
+++ b/packaging/rpm/smoldesk.spec
@@ -4,7 +4,7 @@ Release:        1%{?dist}
 Summary:        WebRTC-based Remote Desktop for Linux
 
 License:        MIT
-URL:            https://github.com/SmolDesk/SmolDesk
+URL:            https://github.com/EcoSphereNetwork/SmolDesk
 Source0:        %{name}-%{version}.tar.gz
 
 BuildRequires:  nodejs >= 16

--- a/scripts/codex-create-issue.sh
+++ b/scripts/codex-create-issue.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# usage: ./codex-create-issue.sh "Title" "Body"
+
+gh issue create --title "$1" --body "$2" --label "conflict"


### PR DESCRIPTION
## Summary
- add `.github/CODEX.md` with basic agent rules
- create `codex-create-issue.sh` helper
- expand `AGENTS.md` with agent types
- update `AGENTS_DEV_GUIDE.md` and docs
- reference agents in README and CI docs
- update `.codex.json` with repo settings
- fix repo path in codex config
- update repository links to EcoSphereNetwork

## Testing
- `npm test` *(fails: vitest not found)*
- `cargo test` *(fails: could not find `Cargo.toml`)*

------
https://chatgpt.com/codex/tasks/task_e_68518ff370588324af1f3edef232d856