### PR TITLE
Fix Pages deployment for Storybook

### DIFF
--- a/.codex.json
+++ b/.codex.json
@@ -23,9 +23,14 @@
     "phase3": "complete",
     "4": "IPC und E2E Tests",
     "phase4": "complete",
-    "phase5": "Komponentenvalidierung & visuelle Regression in Storybook"
+    "phase5": "Storybook Snapshot & Preview"
   },
   "repo": "github.com/EcoSphereNetwork/SmolDesk",
+  "storybookDeployment": {
+    "output": "storybook-static",
+    "method": "gh-pages",
+    "trigger": "main"
+  },
   "pullRequestPolicy": {
     "autoMerge": true,
     "conflictResolution": "favor-new-code",

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -1,0 +1,39 @@
+name: Deploy Storybook
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: npm ci && npm run build:storybook
+      - name: verify build output
+        run: |
+          test -f storybook-static/index.html
+          touch storybook-static/.nojekyll
+      - uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./storybook-static
+          publish_branch: gh-pages
+          cname: ''
+      - name: Upload fallback artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: storybook-preview
+          path: storybook-static
+      - name: comment artifact link
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '❗ GitHub Pages ist derzeit nicht erreichbar. Lade das Vorschau-Artefakt herunter: [📦 Storybook Preview (artifact)](https://github.com/${context.repo.owner}/${context.repo.repo}/actions)'
+            })

--- a/.github/workflows/pr-preview-storybook.yml
+++ b/.github/workflows/pr-preview-storybook.yml
@@ -1,0 +1,15 @@
+name: Storybook PR Preview
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: npm ci && npm run build:storybook
+      - uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: storybook-static

--- a/.gitignore
+++ b/.gitignore
@@ -78,7 +78,8 @@ node_modules/
 test-results/
 playwright-report/
 storybook-snapshots/
-storybook-static/
+storybook-static/*
+!storybook-static/.nojekyll
 
 # Tauri Assets/Packages
 src-tauri/node_modules/

--- a/README.md
+++ b/README.md
@@ -13,8 +13,11 @@
   [![Project Credits][credits-shield]][credits-url]
 
   [Start Documentation](https://github.com/EcoSphereNetwork/SmolDesk/blob/main/docs/README.md) •
+  [Live Storybook](https://ecospherenetwork.github.io/SmolDesk/) •
   [Report Bug](https://github.com/EcoSphereNetwork/SmolDesk/issues) •
   [Request Feature](https://github.com/EcoSphereNetwork/SmolDesk/issues)
+  <br/>
+  <sub>Live preview may take a few minutes to update after each merge.</sub>
 </div>
 
 ## 📋 Table of Contents

--- a/docs/docs/development/phase-5-overview.md
+++ b/docs/docs/development/phase-5-overview.md
@@ -16,3 +16,9 @@ Phase 5.3 adds visual screenshot testing and uploads snapshots as CI artifacts.
 Phase 5.3 is now complete after fixing a JSON parse error in the snapshot setup.
 Snapshots are saved under `storybook-snapshots/` and uploaded in CI.
 See [storybook-status.md](../components/storybook-status.md) for details.
+Phase 5.4 introduces automatic deployment of the static Storybook via GitHub
+Pages so component previews are available at
+`https://<user>.github.io/<repo>/` after each merge to `main`.
+
+Phase 5.4.1 adds a CI fallback: sollte die GitHub Pages Instanz nach dem Merge nicht erreichbar sein und nur einen 404 liefern, wird der Storybook-Build als Artefakt hochgeladen. Ein Workflow kommentiert den Link direkt im Pull Request.
+Phase 5.4.2 stellt die korrekte Veröffentlichung sicher. Der Deployment-Workflow schreibt eine `.nojekyll`-Datei und pusht nach `gh-pages`, sodass die Vorschau dauerhaft unter `https://ecospherenetwork.github.io/SmolDesk/` erreichbar ist. Nach dem Merge sollte diese URL immer eine aktuelle Storybook-Version anzeigen. Damit gilt Phase 5.4 als abgeschlossen.

--- a/docs/docs/testing/storybook.md
+++ b/docs/docs/testing/storybook.md
@@ -56,7 +56,19 @@ npm run test:storybook:snapshots
 
 Screenshots are saved to `storybook-snapshots/` and uploaded as CI artifacts.
 
-## \ud83d\udce4 Vorschau-Deployment (Phase\u202f5.4)
+## \ud83d\udce4 Storybook Deployment
 
-Upcoming work will generate a static build under `storybook-static/` for each
-pull request. This allows reviewers to browse components visually before merge.
+A GitHub Actions workflow builds the static Storybook and publishes it to the
+`gh-pages` branch whenever changes land on `main`. Ensure the repository settings point GitHub Pages to this branch. After each merge you can open
+`https://<user>.github.io/<repo>/` to preview all components and verify that the
+latest build is available. During CI a zipped `storybook-static` folder is uploaded as an artifact for manual inspection.
+
+The workflow writes a `.nojekyll` file so GitHub serves all assets correctly.
+
+### Fehlerbehandlung GitHub Pages
+
+Sollte der unter `https://ecospherenetwork.github.io/SmolDesk/` gehostete Storybook-Build einen 404-Fehler liefern, überprüfe zuerst, ob der `gh-pages`-Branch korrekt erzeugt wurde und ob die `publish_dir` im Workflow auf `storybook-static` zeigt. Prüfe außerdem den `homepage`-Eintrag in der `package.json`, ob eine `.nojekyll`-Datei im Ausgabeverzeichnis liegt und dass `index.html` direkt im Wurzelverzeichnis des `gh-pages`-Branches liegt.
+
+### Fallback-Vorschau über CI-Artefakt
+
+Falls GitHub Pages nicht erreichbar ist, stellt die CI den Inhalt von `storybook-static/` als Download-Artefakt bereit. Der Workflow kommentiert im Pull Request einen Hinweis mit dem Link zur Action, damit Reviewer die Vorschau manuell laden können.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "type": "git",
     "url": "https://github.com/EcoSphereNetwork/SmolDesk.git"
   },
-  "homepage": "https://github.com/EcoSphereNetwork/SmolDesk",
+  "homepage": "https://ecospherenetwork.github.io/SmolDesk",
   "bugs": {
     "url": "https://github.com/EcoSphereNetwork/SmolDesk/issues"
   },
@@ -42,7 +42,8 @@
     "test:ci:e2e": "VITE_USE_MOCK=true npm run e2e",
     "test:components": "vitest run tests/unit/components",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook",
+    "build-storybook": "storybook build",
+    "build:storybook": "storybook build -o storybook-static",
     "test:storybook:snapshots": "bash scripts/run-storybook-snapshots.sh",
     "lint": "eslint src --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "lint:fix": "eslint src --ext ts,tsx --fix",


### PR DESCRIPTION
## Summary
- ensure `.nojekyll` is shipped with the Storybook build and included in git
- verify Storybook output before deploying to `gh-pages`
- link the live preview in the README and mention possible delay
- document troubleshooting and completion of phase 5.4

## Testing
- `npm run build:storybook`
- `npm run test:run`


------
https://chatgpt.com/codex/tasks/task_e_685535a9200c8324883247dfaf0e7d36