### PR TITLE
Fix GitHub Pages preview

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -14,6 +14,17 @@ jobs:
         run: |
           test -f storybook-static/index.html
           touch storybook-static/.nojekyll
+          cp storybook-static/index.html storybook-static/404.html # reuse index for 404 page
+      - name: Force-push to gh-pages
+        run: |
+          git config --global user.name "codex-ci"
+          git config --global user.email "ci@codex.local"
+          git checkout --orphan gh-pages
+          git reset
+          cp -r storybook-static/* .
+          git add .
+          git commit -m "chore: publish storybook"
+          git push --force origin gh-pages
       - uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
   [Request Feature](https://github.com/EcoSphereNetwork/SmolDesk/issues)
   <br/>
   <sub>Live preview may take a few minutes to update after each merge.</sub>
+  <br/>
+  <sub><strong>Live Preview (aktualisiert nach jeder Änderung):</strong> <https://ecospherenetwork.github.io/SmolDesk/></sub>
 </div>
 
 ## 📋 Table of Contents

--- a/docs/docs/development/phase-5-overview.md
+++ b/docs/docs/development/phase-5-overview.md
@@ -21,4 +21,4 @@ Pages so component previews are available at
 `https://<user>.github.io/<repo>/` after each merge to `main`.
 
 Phase 5.4.1 adds a CI fallback: sollte die GitHub Pages Instanz nach dem Merge nicht erreichbar sein und nur einen 404 liefern, wird der Storybook-Build als Artefakt hochgeladen. Ein Workflow kommentiert den Link direkt im Pull Request.
-Phase 5.4.2 stellt die korrekte Veröffentlichung sicher. Der Deployment-Workflow schreibt eine `.nojekyll`-Datei und pusht nach `gh-pages`, sodass die Vorschau dauerhaft unter `https://ecospherenetwork.github.io/SmolDesk/` erreichbar ist. Nach dem Merge sollte diese URL immer eine aktuelle Storybook-Version anzeigen. Damit gilt Phase 5.4 als abgeschlossen.
+Phase 5.4.2 stellt die korrekte Veröffentlichung sicher. Der Deployment-Workflow schreibt eine `.nojekyll`-Datei und pusht nach `gh-pages`, sodass die Vorschau dauerhaft unter `https://ecospherenetwork.github.io/SmolDesk/` erreichbar ist. Sobald dort ein `200 OK` erscheint und die Vorschau sichtbar ist, gilt Phase 5.4 als abgeschlossen.

--- a/docs/docs/testing/storybook.md
+++ b/docs/docs/testing/storybook.md
@@ -69,6 +69,7 @@ The workflow writes a `.nojekyll` file so GitHub serves all assets correctly.
 ### Fehlerbehandlung GitHub Pages
 
 Sollte der unter `https://ecospherenetwork.github.io/SmolDesk/` gehostete Storybook-Build einen 404-Fehler liefern, überprüfe zuerst, ob der `gh-pages`-Branch korrekt erzeugt wurde und ob die `publish_dir` im Workflow auf `storybook-static` zeigt. Prüfe außerdem den `homepage`-Eintrag in der `package.json`, ob eine `.nojekyll`-Datei im Ausgabeverzeichnis liegt und dass `index.html` direkt im Wurzelverzeichnis des `gh-pages`-Branches liegt.
+Stelle sicher, dass keine zusätzliche Unterordner-Struktur (`/SmolDesk/`) im Branch vorhanden ist und die GitHub-Pages-Einstellungen auf den Branch `gh-pages` mit dem Stammverzeichnis `(root)` zeigen. Leere den Browser-Cache oder lade die Seite hart neu, falls eine veraltete 404-Seite gezeigt wird.
 
 ### Fallback-Vorschau über CI-Artefakt
 


### PR DESCRIPTION
## Summary
- deploy Storybook with explicit orphan push
- copy index.html to 404 page during deployment
- mention live preview URL in README
- document GitHub Pages troubleshooting and confirm phase 5.4.2

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685558f3865c8324b2907a8d725fb05a