### PR TITLE
Initialize React Native mobile project

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,13 @@
+# SmolDesk-Mobile Documentation Guide
+
+## Development Status
+- [ ] Phase 1: Projektinitialisierung
+- [ ] Phase 2: Signaling & WebRTC
+- [ ] Phase 3: Viewer UI
+- [ ] Weitere Phasen siehe `Smodesk-Mobile.md`
+
+## Architecture
+Siehe `docs/docs/development/Smodesk-Mobile-Architektur.md` für eine Übersicht der Hauptkomponenten.
+
+## Testing Strategy
+Alle neuen Features sollten mit Jest getestet werden. E2E-Tests können später mit Detox erfolgen.

--- a/docs/docs/development/Smodesk-Mobile-Architektur.md
+++ b/docs/docs/development/Smodesk-Mobile-Architektur.md
@@ -1,0 +1,8 @@
+# SmolDesk Mobile Architektur
+
+Die Mobile-App verwendet React Native und verbindet sich über WebRTC mit dem SmolDesk Signaling-Server. Die App bildet den Remote-Bildschirm als Videostream ab und sendet Eingaben über Datenkanäle.
+
+## Hauptkomponenten
+- **Signaling Service**: WebSocket Verbindung zum bestehenden Node.js Server
+- **WebRTC Service**: Aufbau der PeerConnection, Empfang des Video-Streams
+- **UI**: React-Native-Komponenten zur Anzeige des Streams und für Steuerelemente

--- a/docs/docs/development/Smodesk-Mobile-Testplan.md
+++ b/docs/docs/development/Smodesk-Mobile-Testplan.md
@@ -1,0 +1,5 @@
+# Testplan für SmolDesk Mobile
+
+1. **Unit Tests** mit Jest für Hilfsfunktionen und Services
+2. **Manuelle Tests** der Verbindung zu einem Linux-Host
+3. **UI-Tests** optional mit Detox

--- a/docs/docs/development/Smodesk-Mobile-UX.md
+++ b/docs/docs/development/Smodesk-Mobile-UX.md
@@ -1,0 +1,5 @@
+# UX Leitfaden für SmolDesk Mobile
+
+- Touch-Gesten für Maus- und Scroll-Steuerung
+- Pinch-to-Zoom im Viewer
+- Minimale UI-Elemente, die einblendbar sind

--- a/mobile/.eslintrc.js
+++ b/mobile/.eslintrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  root: true,
+  extends: ['@react-native-community'],
+};

--- a/mobile/.prettierrc
+++ b/mobile/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/mobile/AGENTS.md
+++ b/mobile/AGENTS.md
@@ -1,0 +1,20 @@
+# SmolDesk-Mobile Development
+
+## Feature Status
+- [ ] Projektinitialisierung
+- [ ] Signaling & WebRTC
+- [ ] Viewer UI
+- [ ] Eingabesteuerung
+- [ ] Clipboard-Sync
+- [ ] Dateiübertragung
+- [ ] Multi-Monitor
+- [ ] Sicherheitsfeatures
+
+## Technical Notes
+- React Native app targeting Android first
+- WebRTC via `react-native-webrtc`
+- Navigation with `@react-navigation/native`
+
+## Testing & Deployment
+- Local testing via `npm run android` or `npm run ios`
+- Jest used for unit tests

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -1,0 +1,24 @@
+# SmolDesk Mobile
+
+React Native client for the SmolDesk remote desktop service.
+
+## Requirements
+- Node.js 18+
+- Android Studio or Xcode for platform builds
+
+## Setup
+```bash
+npm install
+```
+
+## Run on Android
+```bash
+npm run android
+```
+
+## Run on iOS
+```bash
+npm run ios
+```
+
+The app uses the existing SmolDesk signaling server to establish a WebRTC connection.

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -1,0 +1,4 @@
+{
+  "name": "SmolDeskMobile",
+  "displayName": "SmolDesk"
+}

--- a/mobile/babel.config.js
+++ b/mobile/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: ['module:metro-react-native-babel-preset'],
+};

--- a/mobile/index.js
+++ b/mobile/index.js
@@ -1,0 +1,5 @@
+import {AppRegistry} from 'react-native';
+import App from './src/App';
+import {name as appName} from './app.json';
+
+AppRegistry.registerComponent(appName, () => App);

--- a/mobile/jest.config.js
+++ b/mobile/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'react-native',
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+};

--- a/mobile/metro.config.js
+++ b/mobile/metro.config.js
@@ -1,0 +1,17 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { getDefaultConfig } = require('metro-config');
+
+module.exports = (async () => {
+  const {
+    resolver: { sourceExts, assetExts },
+  } = await getDefaultConfig();
+  return {
+    transformer: {
+      babelTransformerPath: require.resolve('react-native-svg-transformer'),
+    },
+    resolver: {
+      assetExts: assetExts.filter((ext) => ext !== 'svg'),
+      sourceExts: [...sourceExts, 'svg', 'ts', 'tsx'],
+    },
+  };
+})();

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,95 +1,36 @@
 {
   "name": "smoldesk-mobile",
-  "version": "1.0.0",
-  "description": "Mobile viewer application for SmolDesk remote desktop",
+  "version": "0.1.0",
   "private": true,
-  "type": "module",
   "scripts": {
-    "android:dev": "tauri android dev",
-    "android:build": "tauri android build",
-    "android:build:release": "tauri android build --release",
-    "ios:dev": "tauri ios dev",
-    "ios:build": "tauri ios build", 
-    "ios:build:release": "tauri ios build --release",
-    "capacitor:sync": "capacitor sync",
-    "capacitor:run:android": "capacitor run android",
-    "capacitor:run:ios": "capacitor run ios",
-    "capacitor:build": "capacitor build",
-    "dev": "vite",
-    "build": "vite build",
-    "preview": "vite preview",
-    "lint": "eslint . --ext js,jsx,ts,tsx",
-    "type-check": "tsc --noEmit"
+    "android": "react-native run-android",
+    "ios": "react-native run-ios",
+    "start": "react-native start",
+    "test": "jest",
+    "lint": "eslint . --ext js,jsx,ts,tsx"
   },
-  "keywords": [
-    "mobile",
-    "tauri",
-    "android",
-    "ios",
-    "capacitor",
-    "remote-desktop",
-    "viewer"
-  ],
-  "author": "SmolDesk Team",
-  "license": "MIT",
   "dependencies": {
-    "@tauri-apps/api": "^1.5.1",
-    "@tauri-apps/plugin-shell": "^1.0.0",
-    "@capacitor/core": "^5.5.0",
-    "@capacitor/android": "^5.5.0",
-    "@capacitor/ios": "^5.5.0",
-    "@capacitor/splash-screen": "^5.0.0",
-    "@capacitor/status-bar": "^5.0.0",
-    "@capacitor/keyboard": "^5.0.0",
-    "@capacitor/device": "^5.0.0",
-    "@capacitor/network": "^5.0.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "react-router-dom": "^6.0.0",
-    "lucide-react": "^0.263.1",
-    "clsx": "^2.0.0"
+    "react": "18.2.0",
+    "react-native": "0.73.4",
+    "@react-navigation/native": "^6.1.7",
+    "@react-navigation/native-stack": "^6.9.12",
+    "react-native-screens": "^3.29.0",
+    "react-native-safe-area-context": "^4.7.1",
+    "react-native-webrtc": "^1.108.0"
   },
   "devDependencies": {
-    "@capacitor/cli": "^5.5.0",
-    "@tauri-apps/cli": "^1.5.6",
-    "@types/react": "^18.2.15",
-    "@types/react-dom": "^18.2.7",
-    "@typescript-eslint/eslint-plugin": "^6.0.0",
-    "@typescript-eslint/parser": "^6.0.0",
-    "@vitejs/plugin-react": "^4.0.3",
-    "typescript": "^5.0.2",
-    "vite": "^4.4.5",
-    "eslint": "^8.45.0",
-    "eslint-plugin-react": "^7.32.2",
-    "eslint-plugin-react-hooks": "^4.6.0"
+    "@babel/core": "^7.22.5",
+    "@babel/runtime": "^7.22.5",
+    "@react-native-community/eslint-config": "^3.2.0",
+    "@types/react": "^18.2.21",
+    "@types/react-native": "^0.72.3",
+    "typescript": "^5.2.2",
+    "eslint": "^8.57.0",
+    "jest": "^29.7.0",
+    "metro-react-native-babel-preset": "^0.78.6",
+    "react-test-renderer": "18.2.0"
   },
   "engines": {
-    "node": ">=18.0.0",
-    "npm": ">=9.0.0"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/your-org/smoldesk.git",
-    "directory": "mobile"
-  },
-  "capacitor": {
-    "appId": "com.smoldesk.mobile",
-    "appName": "SmolDesk",
-    "webDir": "dist",
-    "server": {
-      "androidScheme": "https"
-    },
-    "plugins": {
-      "SplashScreen": {
-        "launchShowDuration": 2000,
-        "backgroundColor": "#1f2937",
-        "androidScaleType": "CENTER_CROP",
-        "showSpinner": true,
-        "spinnerColor": "#3b82f6"
-      },
-      "StatusBar": {
-        "style": "dark"
-      }
-    }
+    "node": ">=18.0.0"
   }
 }

--- a/mobile/src/App.tsx
+++ b/mobile/src/App.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { SafeAreaView, Text } from 'react-native';
+
+const App = () => (
+  <SafeAreaView style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+    <Text>SmolDesk Mobile</Text>
+  </SafeAreaView>
+);
+
+export default App;

--- a/mobile/tsconfig.json
+++ b/mobile/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "module": "commonjs",
+    "strict": true,
+    "noEmit": true,
+    "jsx": "react",
+    "types": ["react", "react-native"],
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true
+  },
+  "exclude": ["node_modules", "babel.config.js", "metro.config.js", "jest.config.js"]
+}


### PR DESCRIPTION
## Summary
- set up `mobile` folder as a React Native project
- add ESLint and Prettier configs
- create initial app source and config files
- document the architecture, UX and test plan for the mobile app
- add AGENTS files to track progress

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b66f3825083249e5ac43ee4c2c55d