### PR TITLE
Implement SmolDesk Mobile signaling and WebRTC

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,3 +146,8 @@ Links to key progress documents are kept here for reference:
 - [Playwright Guide](docs/docs/testing/playwright.md)
 - [Phase 5 Overview](docs/docs/development/phase-5-overview.md)
 
+
+## Mobile Status
+- [x] Signaling-Verbindung implementiert
+- [x] WebRTC PeerConnection mit ICE & SDP
+- [x] Videoanzeige mit RTCView

--- a/docs/docs/development/Smodesk-Mobile-Signaling.md
+++ b/docs/docs/development/Smodesk-Mobile-Signaling.md
@@ -1,0 +1,32 @@
+# SmolDesk Mobile Signaling
+
+Dieses Dokument beschreibt die Nachrichtenformate und den Ablauf der WebSocket-Kommunikation zwischen der Mobile-App und dem SmolDesk Signaling-Server.
+
+## Verbindungsablauf
+1. Die App stellt eine WebSocket-Verbindung zu `wss://<server>` her.
+2. Nach dem Verbindungsaufbau sendet der Server eine `welcome`-Nachricht mit `clientId` und `token`.
+3. Anschließend tritt der Client mit `join-room` einem Raum bei und wartet auf ein `offer` des Hosts.
+4. Nach dem SDP-Austausch werden ICE-Kandidaten mittels `ice-candidate` ausgetauscht.
+
+## Nachrichten vom Client
+- `create-room` { `roomId?`, `settings?` }
+- `join-room` { `roomId` }
+- `leave-room`
+- `offer` { `targetId`, `offer` }
+- `answer` { `targetId`, `answer` }
+- `ice-candidate` { `targetId`, `candidate` }
+- `ping`
+
+## Nachrichten vom Server
+- `welcome` { `clientId`, `token` }
+- `room-created` { `roomId` }
+- `room-joined` { `roomId`, `peers`, `settings` }
+- `room-left` { `roomId` }
+- `peer-joined` { `peerId` }
+- `peer-left` { `peerId` }
+- `peer-disconnected` { `peerId` }
+- `offer` { `peerId`, `offer` }
+- `answer` { `peerId`, `answer` }
+- `ice-candidate` { `peerId`, `candidate` }
+- `error` { `message` }
+- `pong`

--- a/mobile/AGENTS.md
+++ b/mobile/AGENTS.md
@@ -2,8 +2,8 @@
 
 ## Feature Status
 - [ ] Projektinitialisierung
-- [ ] Signaling & WebRTC
-- [ ] Viewer UI
+- [x] Signaling & WebRTC
+- [x] Viewer UI
 - [ ] Eingabesteuerung
 - [ ] Clipboard-Sync
 - [ ] Dateiübertragung

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -22,3 +22,6 @@ npm run ios
 ```
 
 The app uses the existing SmolDesk signaling server to establish a WebRTC connection.
+
+## Configuration
+The signaling server URL can be adjusted in `src/config.ts` or by editing the input field on the connect screen at runtime.

--- a/mobile/__tests__/signaling.test.ts
+++ b/mobile/__tests__/signaling.test.ts
@@ -1,0 +1,19 @@
+import { Server } from 'ws';
+import SignalingService from '../src/services/signaling';
+
+describe('SignalingService', () => {
+  test('connects and handles messages', (done) => {
+    const server = new Server({ port: 12345 }, () => {
+      const service = new SignalingService({ url: 'ws://localhost:12345' });
+      service.on('open', () => {
+        server.clients.forEach((ws) => ws.send(JSON.stringify({ type: 'welcome' })));
+      });
+      service.on('message', (msg) => {
+        expect(msg.type).toBe('welcome');
+        server.close();
+        done();
+      });
+      service.connect();
+    });
+  });
+});

--- a/mobile/src/App.tsx
+++ b/mobile/src/App.tsx
@@ -1,10 +1,49 @@
-import React from 'react';
-import { SafeAreaView, Text } from 'react-native';
+import React, { useState } from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import ConnectScreen from './screens/ConnectScreen';
+import ViewerScreen from './screens/ViewerScreen';
+import SignalingService from './services/signaling';
+import WebRTCService from './services/webrtc';
+import { MediaStream } from 'react-native-webrtc';
 
-const App = () => (
-  <SafeAreaView style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-    <Text>SmolDesk Mobile</Text>
-  </SafeAreaView>
-);
+const Stack = createNativeStackNavigator();
 
-export default App;
+export default function App() {
+  const [webrtc, setWebrtc] = useState<WebRTCService | null>(null);
+  const [stream, setStream] = useState<MediaStream | null>(null);
+
+  const handleConnect = (server: string, room: string) => {
+    const signaling = new SignalingService({ url: server });
+    const service = new WebRTCService({ signaling });
+    service.on('stream', setStream);
+    signaling.on('close', () => {
+      setStream(null);
+      setWebrtc(null);
+    });
+    service.join(room);
+    setWebrtc(service);
+  };
+
+  const handleDisconnect = () => {
+    webrtc?.disconnect();
+    setStream(null);
+    setWebrtc(null);
+  };
+
+  return (
+    <NavigationContainer>
+      <Stack.Navigator screenOptions={{ headerShown: false }}>
+        {stream ? (
+          <Stack.Screen name="viewer">
+            {() => <ViewerScreen stream={stream!} onDisconnect={handleDisconnect} />}
+          </Stack.Screen>
+        ) : (
+          <Stack.Screen name="connect">
+            {() => <ConnectScreen onConnect={handleConnect} />}
+          </Stack.Screen>
+        )}
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/mobile/src/config.ts
+++ b/mobile/src/config.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_SIGNALING_SERVER = 'wss://signaling.smoldesk.example';

--- a/mobile/src/screens/ConnectScreen.tsx
+++ b/mobile/src/screens/ConnectScreen.tsx
@@ -1,0 +1,40 @@
+import React, { useState } from 'react';
+import { View, TextInput, Button, StyleSheet } from 'react-native';
+import { DEFAULT_SIGNALING_SERVER } from '../config';
+
+interface Props {
+  onConnect: (server: string, room: string) => void;
+}
+
+export default function ConnectScreen({ onConnect }: Props) {
+  const [serverUrl, setServerUrl] = useState(DEFAULT_SIGNALING_SERVER);
+  const [roomId, setRoomId] = useState('');
+
+  return (
+    <View style={styles.container}>
+      <TextInput
+        style={styles.input}
+        placeholder="Server URL"
+        value={serverUrl}
+        onChangeText={setServerUrl}
+      />
+      <TextInput
+        style={styles.input}
+        placeholder="Raumcode"
+        value={roomId}
+        onChangeText={setRoomId}
+      />
+      <Button title="Verbinden" onPress={() => onConnect(serverUrl, roomId)} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', padding: 20 },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    marginBottom: 10,
+    padding: 8,
+  },
+});

--- a/mobile/src/screens/ViewerScreen.tsx
+++ b/mobile/src/screens/ViewerScreen.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { View, StyleSheet, Button } from 'react-native';
+import { RTCView, MediaStream } from 'react-native-webrtc';
+
+interface Props {
+  stream: MediaStream;
+  onDisconnect: () => void;
+}
+
+export default function ViewerScreen({ stream, onDisconnect }: Props) {
+  return (
+    <View style={styles.container}>
+      <RTCView
+        streamURL={stream.toURL()}
+        style={styles.video}
+        objectFit="cover"
+      />
+      <View style={styles.toolbar}>
+        <Button title="Verbindung trennen" onPress={onDisconnect} />
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#000' },
+  video: { flex: 1 },
+  toolbar: {
+    position: 'absolute',
+    bottom: 20,
+    left: 0,
+    right: 0,
+    alignItems: 'center',
+  },
+});

--- a/mobile/src/services/signaling.ts
+++ b/mobile/src/services/signaling.ts
@@ -1,0 +1,91 @@
+import { EventEmitter } from 'events';
+
+export interface SignalingOptions {
+  url: string;
+  reconnectInterval?: number;
+}
+
+export type SignalingMessage = {
+  type: string;
+  [key: string]: any;
+};
+
+export declare interface SignalingService {
+  on(event: 'open', listener: () => void): this;
+  on(event: 'close', listener: () => void): this;
+  on(event: 'message', listener: (msg: SignalingMessage) => void): this;
+  on(event: 'error', listener: (err: any) => void): this;
+}
+
+export class SignalingService extends EventEmitter {
+  private url: string;
+  private reconnectInterval: number;
+  private socket: WebSocket | null = null;
+  private reconnectTimer: NodeJS.Timeout | null = null;
+
+  constructor(options: SignalingOptions) {
+    super();
+    this.url = options.url;
+    this.reconnectInterval = options.reconnectInterval ?? 5000;
+  }
+
+  connect() {
+    if (this.socket && this.socket.readyState === WebSocket.OPEN) {
+      return;
+    }
+    this.socket = new WebSocket(this.url);
+
+    this.socket.onopen = () => {
+      this.emit('open');
+    };
+
+    this.socket.onclose = () => {
+      this.emit('close');
+      if (this.reconnectTimer) return;
+      this.reconnectTimer = setTimeout(() => {
+        this.reconnectTimer = null;
+        this.connect();
+      }, this.reconnectInterval);
+    };
+
+    this.socket.onerror = (err) => {
+      this.emit('error', err);
+    };
+
+    this.socket.onmessage = (ev) => {
+      try {
+        const msg: SignalingMessage = JSON.parse(ev.data);
+        this.emit('message', msg);
+      } catch (e) {
+        this.emit('error', e);
+      }
+    };
+  }
+
+  disconnect() {
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    if (this.socket) {
+      this.socket.close();
+      this.socket = null;
+    }
+  }
+
+  send(msg: SignalingMessage) {
+    if (this.socket && this.socket.readyState === WebSocket.OPEN) {
+      this.socket.send(JSON.stringify(msg));
+    }
+  }
+
+  joinRoom(roomId: string) {
+    this.send({ type: 'join-room', roomId });
+  }
+
+  leaveRoom() {
+    this.send({ type: 'leave-room' });
+  }
+}
+
+export default SignalingService;

--- a/mobile/src/services/webrtc.ts
+++ b/mobile/src/services/webrtc.ts
@@ -1,0 +1,110 @@
+import { EventEmitter } from 'events';
+import {
+  RTCPeerConnection,
+  RTCSessionDescription,
+  RTCIceCandidate,
+  MediaStream,
+} from 'react-native-webrtc';
+import SignalingService, { SignalingMessage } from './signaling';
+
+export interface WebRTCServiceOptions {
+  signaling: SignalingService;
+  iceServers?: RTCIceServer[];
+}
+
+export declare interface WebRTCService {
+  on(event: 'stream', listener: (stream: MediaStream) => void): this;
+  on(event: 'connectionState', listener: (state: RTCPeerConnectionState) => void): this;
+}
+
+export class WebRTCService extends EventEmitter {
+  private signaling: SignalingService;
+  private iceServers: RTCIceServer[];
+  private pc: RTCPeerConnection | null = null;
+
+  constructor(options: WebRTCServiceOptions) {
+    super();
+    this.signaling = options.signaling;
+    this.iceServers = options.iceServers ?? [{ urls: 'stun:stun.l.google.com:19302' }];
+
+    this.signaling.on('message', this.handleSignal.bind(this));
+  }
+
+  async join(roomId: string) {
+    this.signaling.connect();
+    this.signaling.joinRoom(roomId);
+  }
+
+  private createPeer() {
+    if (this.pc) return;
+    this.pc = new RTCPeerConnection({ iceServers: this.iceServers });
+
+    this.pc.onicecandidate = (e) => {
+      if (e.candidate) {
+        this.signaling.send({
+          type: 'ice-candidate',
+          targetId: this.remoteId,
+          candidate: e.candidate,
+        });
+      }
+    };
+
+    this.pc.ontrack = (ev) => {
+      const stream = ev.streams[0];
+      if (stream) {
+        this.emit('stream', stream);
+      }
+    };
+
+    this.pc.onconnectionstatechange = () => {
+      if (this.pc) {
+        this.emit('connectionState', this.pc.connectionState);
+      }
+    };
+  }
+
+  private remoteId: string | null = null;
+
+  private async handleSignal(msg: SignalingMessage) {
+    switch (msg.type) {
+      case 'offer':
+        this.remoteId = msg.peerId;
+        await this.handleOffer(msg.offer);
+        break;
+      case 'answer':
+        await this.pc?.setRemoteDescription(new RTCSessionDescription(msg.answer));
+        break;
+      case 'ice-candidate':
+        if (this.pc) {
+          await this.pc.addIceCandidate(new RTCIceCandidate(msg.candidate));
+        }
+        break;
+      default:
+        break;
+    }
+  }
+
+  private async handleOffer(offer: RTCSessionDescriptionInit) {
+    this.createPeer();
+    if (!this.pc) return;
+
+    await this.pc.setRemoteDescription(new RTCSessionDescription(offer));
+    const answer = await this.pc.createAnswer();
+    await this.pc.setLocalDescription(answer);
+
+    if (this.remoteId) {
+      this.signaling.send({ type: 'answer', targetId: this.remoteId, answer });
+    }
+  }
+
+  disconnect() {
+    this.signaling.leaveRoom();
+    this.signaling.disconnect();
+    if (this.pc) {
+      this.pc.close();
+      this.pc = null;
+    }
+  }
+}
+
+export default WebRTCService;


### PR DESCRIPTION
## Summary
- add configurable server URL for mobile app
- implement signaling service with reconnection
- integrate WebRTC peer connection service
- show viewer screen with RTCView and connect UI
- document mobile signaling protocol
- update agent status for new phase

## Testing
- `npm test --silent` *(fails: Test run cancelled)*
- `cargo test --quiet` *(failed: glib-2.0 not found)*
- `npm test --silent` in mobile *(failed: Preset react-native not found)*


------
https://chatgpt.com/codex/tasks/task_e_686b6d3369ec83249831b7ab18f47c26