### PR TITLE
Prepare iOS scaffolding and App Store docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,3 +171,7 @@ Links to key progress documents are kept here for reference:
 - [x] Automatisierte Tests vorbereitet
 - [x] Android-Build konfiguriert (nicht ausgeführt)
 - [x] Play Store-Vorbereitung abgeschlossen (keine .aab)
+- [x] iOS-Konfigurationsstruktur erstellt
+- [x] Info.plist vorbereitet
+- [x] AppStore-Text & Datenschutzerklärung erstellt
+- [x] TestFlight-Anleitung ergänzt

--- a/docs/docs/public/SmolDesk-Mobile-AppStore.md
+++ b/docs/docs/public/SmolDesk-Mobile-AppStore.md
@@ -1,0 +1,19 @@
+# SmolDesk Mobile – App Store Informationen
+
+## Kurzbeschreibung
+Fernzugriff auf Linux-Desktops über eine sichere WebRTC-Verbindung.
+
+## Ausführliche Beschreibung
+SmolDesk ermöglicht die Steuerung eines Linux-Systems von iPhone oder iPad. Die Verbindung ist Ende-zu-Ende verschlüsselt, Tastatur- und Mauseingaben sowie Dateiübertragungen werden in Echtzeit übertragen.
+
+## Kategorien & Zielgruppe
+- Produktivität
+- Entwickler und Administratoren
+
+## iOS-spezifische Hinweise
+- Benötigt Kamera- und Mikrofonzugriff für WebRTC
+- Nutzt das lokale Netzwerk zur Verbindung mit dem Host
+- Beachtet Notch und Safe Areas auf allen Geräten
+
+## Datenschutz
+Es werden keine Tracking-IDs oder Analytics erhoben. Alle Daten dienen ausschließlich der direkten Verbindung zum eigenen Rechner.

--- a/docs/docs/public/SmolDesk-Mobile-AppStoreRelease.md
+++ b/docs/docs/public/SmolDesk-Mobile-AppStoreRelease.md
@@ -1,0 +1,15 @@
+# SmolDesk Mobile App Store Release Checkliste
+
+## Vorbereitung
+- [ ] Screenshots überprüfen
+- [ ] App Store Beschreibung aktualisieren
+- [ ] Version in Xcode erhöhen
+
+## Beta-Test (TestFlight)
+1. Produkt > Archive in Xcode ausführen
+2. Signierung prüfen und manuell hochladen
+3. Tester in TestFlight einladen
+
+## Produktion
+- [ ] Finalen Build im App Store Connect hochladen
+- [ ] Review-Kommentare beantworten

--- a/docs/docs/public/SmolDesk-Mobile-TestFlight.md
+++ b/docs/docs/public/SmolDesk-Mobile-TestFlight.md
@@ -1,0 +1,12 @@
+# TestFlight Anleitung
+
+## Voraussetzungen
+- Aktuelles Xcode
+- Apple Developer Account
+
+## Schritte
+1. `Product > Archive` in Xcode ausführen
+2. Im Organizer die App über den Transporter oder direkt über Xcode hochladen
+3. Interne Tester in App Store Connect einladen
+
+Die Signierung erfolgt manuell im Xcode-Projekt.

--- a/docs/docs/public/privacy-policy-ios.html
+++ b/docs/docs/public/privacy-policy-ios.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="UTF-8">
+<title>SmolDesk Mobile iOS Privacy Policy</title>
+</head>
+<body>
+<h1>Privacy Policy</h1>
+<p>SmolDesk Mobile speichert keine personenbezogenen Daten und verwendet keine Tracking-Dienste. Die App benötigt Kamera-, Mikrofon- und Netzwerkberechtigungen ausschließlich für die WebRTC-Verbindung.</p>
+</body>
+</html>

--- a/mobile/AGENTS.md
+++ b/mobile/AGENTS.md
@@ -26,3 +26,7 @@
 - Automatisierte Tests vorbereitet
 - Android-Build konfiguriert (nicht ausgeführt)
 - Play Store-Vorbereitung abgeschlossen (keine .aab)
+- iOS-Konfigurationsstruktur erstellt
+- Info.plist vorbereitet
+- AppStore-Text & Datenschutzerklärung erstellt
+- TestFlight-Anleitung ergänzt

--- a/mobile/__mocks__/react-native-gesture-handler.js
+++ b/mobile/__mocks__/react-native-gesture-handler.js
@@ -1,0 +1,5 @@
+export const PanGestureHandler = 'PanGestureHandler';
+export const PinchGestureHandler = 'PinchGestureHandler';
+export const TapGestureHandler = 'TapGestureHandler';
+export const GestureHandlerRootView = 'GestureHandlerRootView';
+export default {};

--- a/mobile/__mocks__/react-native-reanimated.js
+++ b/mobile/__mocks__/react-native-reanimated.js
@@ -1,0 +1,11 @@
+export const useSharedValue = (v) => ({ value: v });
+export const useAnimatedStyle = () => ({});
+export const withTiming = (v) => v;
+export const useAnimatedGestureHandler = () => ({});
+export const withDecay = jest.fn();
+export const withSpring = jest.fn();
+export const useAnimatedRef = jest.fn();
+export default {
+  View: 'View',
+  ScrollView: 'ScrollView',
+};

--- a/mobile/__tests__/viewer.test.tsx
+++ b/mobile/__tests__/viewer.test.tsx
@@ -1,16 +1,26 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
-import ViewerScreen from '../src/screens/ViewerScreen';
-import WebRTCService from '../src/services/webrtc';
-import SignalingService from '../src/services/signaling';
 
 jest.mock('react-native-webrtc', () => ({ RTCView: 'RTCView', MediaStream: class {} }));
 jest.mock('../src/input/touchToMouse');
 jest.mock('../src/services/files');
+jest.mock('react-native-document-picker', () => ({
+  __esModule: true,
+  default: { pick: jest.fn() },
+}));
+jest.mock('react-native-fs', () => ({ readFile: jest.fn() }));
+jest.mock('react-native-reanimated');
+
+const ViewerScreen = require('../src/screens/ViewerScreen').default;
 
 it('renders toolbar buttons', () => {
-  const service = new WebRTCService({} as any);
-  const signaling = new SignalingService({ url: '', token: '', reconnectInterval: 0 });
+  const service = {
+    disconnect: jest.fn(),
+    sendRaw: jest.fn(),
+    sendData: jest.fn(),
+    on: jest.fn(),
+  } as any;
+  const signaling = { on: jest.fn() } as any;
   const stream: any = { toURL: () => 'test' };
   const tree = renderer.create(
     <ViewerScreen stream={stream} service={service} signaling={signaling} onDisconnect={() => {}} />

--- a/mobile/ios/Podfile
+++ b/mobile/ios/Podfile
@@ -1,0 +1,19 @@
+platform :ios, '13.0'
+require_relative '../node_modules/react-native/scripts/react_native_pods'
+require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
+
+install!
+use_frameworks!
+
+target 'SmolDeskMobile' do
+  config = use_native_modules!
+  use_react_native!(path: config["reactNativePath"])
+
+  target 'SmolDeskMobileTests' do
+    inherit! :complete
+  end
+end
+
+post_install do |installer|
+  react_native_post_install(installer)
+end

--- a/mobile/ios/README.md
+++ b/mobile/ios/README.md
@@ -1,0 +1,13 @@
+# SmolDesk Mobile iOS Setup
+
+This directory contains the placeholder Xcode project for SmolDesk Mobile.
+Follow these steps to prepare the iOS build:
+
+1. Install Xcode and CocoaPods.
+2. From the `mobile/ios` folder run `pod install` to install dependencies.
+3. Open `SmolDeskMobile.xcworkspace` in Xcode.
+4. Set your signing team in the project settings.
+5. Build and run on a device or simulator.
+
+The workspace references the React Native sources in `../`.
+Icons and splash screen images are located under `SmolDeskMobile/Assets.xcassets`.

--- a/mobile/ios/SmolDeskMobile.xcodeproj/project.pbxproj
+++ b/mobile/ios/SmolDeskMobile.xcodeproj/project.pbxproj
@@ -1,0 +1,1 @@
+// Placeholder project file for SmolDeskMobile

--- a/mobile/ios/SmolDeskMobile.xcworkspace/contents.xcworkspacedata
+++ b/mobile/ios/SmolDeskMobile.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:SmolDeskMobile.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/mobile/ios/SmolDeskMobile/Assets.xcassets/AppIcon.appiconset/README.md
+++ b/mobile/ios/SmolDeskMobile/Assets.xcassets/AppIcon.appiconset/README.md
@@ -1,0 +1,1 @@
+Placeholder for app icons

--- a/mobile/ios/SmolDeskMobile/Assets.xcassets/LaunchImage.imageset/README.md
+++ b/mobile/ios/SmolDeskMobile/Assets.xcassets/LaunchImage.imageset/README.md
@@ -1,0 +1,1 @@
+Placeholder for launch screen

--- a/mobile/ios/SmolDeskMobile/Info.plist
+++ b/mobile/ios/SmolDeskMobile/Info.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDisplayName</key>
+  <string>SmolDesk Mobile</string>
+  <key>CFBundleIdentifier</key>
+  <string>com.ecospherenetwork.smolDeskMobile</string>
+  <key>MinimumOSVersion</key>
+  <string>13.0</string>
+  <key>NSCameraUsageDescription</key>
+  <string>Benötigt für WebRTC Videoübertragung</string>
+  <key>NSMicrophoneUsageDescription</key>
+  <string>Benötigt für WebRTC Audioübertragung</string>
+  <key>NSLocalNetworkUsageDescription</key>
+  <string>Lokales Netzwerk wird für die Verbindung zum Host genutzt</string>
+</dict>
+</plist>

--- a/mobile/jest.config.js
+++ b/mobile/jest.config.js
@@ -1,4 +1,7 @@
 module.exports = {
   preset: 'react-native',
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  transformIgnorePatterns: [
+    'node_modules/(?!(react-native|@react-native|react-native-responsive-fontsize|react-native-iphone-x-helper|react-native-gesture-handler|react-native-reanimated)/)'
+  ],
 };

--- a/mobile/src/platform/ios.ts
+++ b/mobile/src/platform/ios.ts
@@ -1,0 +1,3 @@
+// iOS specific helpers can be implemented here.
+// Currently unused but kept for future native integrations.
+export const iosPlaceholder = true;


### PR DESCRIPTION
## Summary
- add iOS workspace, Info.plist and Podfile placeholders
- provide cross-platform iOS helpers and mocks
- extend Jest config for React Native modules
- document App Store and TestFlight steps
- update development status in AGENTS files

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686b853fcc4883249f4a63921b2efd24