### PR TITLE
📄 Migrate and consolidate UX docs to docs/usage/

### DIFF
--- a/docs/archive/old_docs/Smodesk-Mobile-Eingabe.md
+++ b/docs/archive/old_docs/Smodesk-Mobile-Eingabe.md
@@ -1,3 +1,5 @@
+> ⚠️ Diese Datei wurde archiviert. Der aktuelle Inhalt befindet sich unter `docs/usage/viewer.md`
+
 # SmolDesk Mobile Eingabesteuerung
 
 Dieses Dokument beschreibt die Eingabelogik der Mobile-App.

--- a/docs/archive/old_docs/Smodesk-Mobile-UX.md
+++ b/docs/archive/old_docs/Smodesk-Mobile-UX.md
@@ -1,3 +1,5 @@
+> ⚠️ Diese Datei wurde archiviert. Der aktuelle Inhalt befindet sich unter `docs/usage/viewer.md`
+
 # UX Leitfaden für SmolDesk Mobile
 
 - Touch-Gesten für Maus- und Scroll-Steuerung

--- a/docs/archive/old_docs/USER_GUIDE.md
+++ b/docs/archive/old_docs/USER_GUIDE.md
@@ -1,3 +1,5 @@
+> ⚠️ Diese Datei wurde archiviert. Der aktuelle Inhalt befindet sich unter `docs/usage/viewer.md`
+
 # SmolDesk Benutzerhandbuch
 
 ## Inhaltsverzeichnis

--- a/docs/usage/clipboard.md
+++ b/docs/usage/clipboard.md
@@ -1,0 +1,21 @@
+---
+title: Zwischenablage synchronisieren
+description: Kopiere Inhalte bequem zwischen Host und Client.
+---
+
+[Zurück zum Viewer](./viewer.md)
+
+SmolDesk gleicht die Zwischenablage automatisch ab.
+
+## Desktop
+
+- Text und Bilder (PNG, JPEG, GIF) werden übertragen.
+- HTML wird als Text gesendet.
+- Die Synchronisierung lässt sich in den Einstellungen deaktivieren.
+
+## Mobile
+
+- Aktuell wird nur Text unterstützt.
+- Die App sendet `clipboard`-Nachrichten und schreibt den Inhalt lokal.
+
+![Bild]()

--- a/docs/usage/files.md
+++ b/docs/usage/files.md
@@ -1,0 +1,18 @@
+---
+title: Dateiübertragung
+description: Tausche Dateien zwischen Client und Host.
+---
+
+[Zurück zum Viewer](./viewer.md)
+
+- Ziehe Dateien auf die Anwendung oder wähle **Datei senden**.
+- Mehrere Dateien und Pausieren/Fortsetzen werden unterstützt.
+- Standardmäßig sind 100 MB pro Datei erlaubt.
+
+## Mobile
+
+- Nach einem Tipp auf **Datei senden** öffnet der Dokument-Picker.
+- Die Datei wird in 64 KB Blöcken über WebRTC gesendet.
+- Empfangene Dateien liegen im Download-Ordner und lassen sich teilen.
+
+![Bild]()

--- a/docs/usage/monitors.md
+++ b/docs/usage/monitors.md
@@ -1,0 +1,12 @@
+---
+title: Multi-Monitor
+description: Zwischen verschiedenen Bildschirmen wechseln.
+---
+
+[Zurück zum Viewer](./viewer.md)
+
+- Wechsle während einer Sitzung den genutzten Monitor.
+- Jeder Bildschirm kann eigene Auflösung und Bildrate besitzen.
+- Der Host-Tab zeigt alle erkannten Monitore, im Viewer lässt sich über ein Dialog umschalten.
+
+![Bild]()

--- a/docs/usage/viewer.md
+++ b/docs/usage/viewer.md
@@ -1,0 +1,35 @@
+---
+title: Remote-Desktop steuern
+description: Verbinde dich mit einem Host und bediene den Bildschirm aus der Ferne.
+---
+
+[Zwischenablage](./clipboard.md) · [Dateiübertragung](./files.md) · [Multi-Monitor](./monitors.md)
+
+## Verbindung herstellen
+
+1. Starte SmolDesk und öffne den **View**-Tab.
+2. Gib den Raum-Code ein und klicke auf **Connect**.
+3. Bei geschützten Räumen wird ein Passwort abgefragt.
+
+![Bild]()
+
+## Maus und Tastatur
+
+- Mausbewegungen und Klicks werden direkt an den Host weitergeleitet.
+- Mit **Input On/Off** kannst du die Steuerung pausieren.
+- Vollbildmodus über `F11` oder das Vollbild-Icon.
+
+### Touch-Gesten (Mobile)
+
+| Geste | Aktion |
+|-------|-------|
+| Tap | Linksklick |
+| Long Press | Rechtsklick |
+| 1-Finger-Drag | Mauszeiger bewegen |
+| 2-Finger-Drag | Scrollen |
+| Pinch | Zoom im Viewer |
+
+- Minimale, einblendbare UI-Elemente
+- Darkmode folgt dem System-Theme
+- Snackbar-Feedback bei Verbindung und Dateiübertragungen
+


### PR DESCRIPTION
## Summary
- create usage docs for viewer, clipboard, files and monitors
- archive old user docs with a redirect notice

## Testing
- `npx vitest run` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bad1c02f08324a64789e0aa63ce89