### PR TITLE
Migrate setup docs

### DIFF
--- a/docs/archive/old_docs/Build-Anleitung.md
+++ b/docs/archive/old_docs/Build-Anleitung.md
@@ -1,3 +1,4 @@
+> ⚠️ Diese Datei wurde archiviert. Die aktuelle Version befindet sich unter `docs/development/setup-android.md`
 # 🚀 SmolDesk Build-Anleitung
 
 ## ⚠️ **WICHTIG: Vor dem ersten Build**

--- a/docs/archive/old_docs/Dependencies.md
+++ b/docs/archive/old_docs/Dependencies.md
@@ -1,4 +1,4 @@
-# 📦 SmolDesk Dependencies
+> ⚠️ Diese Datei wurde archiviert. Die aktuelle Version befindet sich unter `docs/development/dev-tools.md`
 
 ## 🚀 **Automatische Installation:**
 

--- a/docs/archive/old_docs/SECURITY.md
+++ b/docs/archive/old_docs/SECURITY.md
@@ -1,4 +1,4 @@
-# SmolDesk Sicherheitsrichtlinien
+> ⚠️ Diese Datei wurde archiviert. Die aktuelle Version befindet sich unter `docs/development/security.md`
 
 ## Sicherheitsarchitektur
 

--- a/docs/archive/old_docs/Smodesk-Mobile-Security.md
+++ b/docs/archive/old_docs/Smodesk-Mobile-Security.md
@@ -1,4 +1,4 @@
-# SmolDesk Mobile Security
+> ⚠️ Diese Datei wurde archiviert. Die aktuelle Version befindet sich unter `docs/development/security.md`
 
 Dieser Abschnitt dokumentiert die Sicherheitsarchitektur der Mobile-App ab Phase 4.
 

--- a/docs/archive/old_docs/Smodesk-Mobile.md
+++ b/docs/archive/old_docs/Smodesk-Mobile.md
@@ -1,4 +1,4 @@
-Entwicklungsplan für die SmolDesk Mobile App
+> ⚠️ Diese Datei wurde archiviert. Die aktuelle Version befindet sich unter `docs/development/setup-android.md`
 
 Ziel: Entwicklung einer plattformübergreifenden React Native App (Android zuerst, danach iOS) für SmolDesk, die alle Funktionen der Desktop-Version unterstützt. SmolDesk ist eine WebRTC-basierte Remote-Desktop-Lösung für Linux mit Fokus auf niedriger Latenz und Sicherheit. Die Mobile-App richtet sich an Endnutzer und soll mobile-first optimiert sein (intuitive Touch-Bedienung, responsives UI etc.). Im Folgenden ein detaillierter Schritt-für-Schritt-Plan:
 

--- a/docs/development/dev-tools.md
+++ b/docs/development/dev-tools.md
@@ -1,0 +1,24 @@
+---
+title: Entwicklerwerkzeuge
+description: Übersicht nützlicher Tools für die SmolDesk-Entwicklung
+---
+
+Dieser Abschnitt listet wichtige Werkzeuge für lokale Entwicklung und Debugging auf.
+
+## Kern-Tools
+
+- **Node.js & npm** – Verwaltung der JavaScript-Abhängigkeiten
+- **Rust Toolchain** – Backend und native Module
+- **Android Studio** mit Emulator für Android-Tests
+- **Xcode** und Simulator für iOS
+- **React Native Debugger** für das Mobile-Frontend
+
+## Nützliche Befehle
+
+```bash
+npm run android   # Startet die Android-App
+npm run ios       # Startet die iOS-App
+npm run security:scan  # Führt den Sicherheitsscan aus
+```
+
+Weitere Hinweise zur Nutzung findest du unter [../usage/viewer.md](../usage/viewer.md).

--- a/docs/development/security.md
+++ b/docs/development/security.md
@@ -1,0 +1,34 @@
+---
+title: Sicherheit
+description: Überblick zu Sicherheitsfunktionen und Härtungsmaßnahmen
+---
+
+Dieser Abschnitt fasst die wichtigsten Sicherheitsaspekte von SmolDesk zusammen. Weitere Nutzungshinweise findest du im [Viewer Guide](../usage/viewer.md).
+
+## Verbindungssicherheit
+
+- Ende-zu-Ende-Verschlüsselung über DTLS 1.2
+- Authentifizierung mittels JWT‑Token
+- Optionaler HMAC‑Schutz für Nachrichten
+- AES‑Verschlüsselung des WebRTC‑Datenkanals
+
+## Datenintegrität und Berechtigungen
+
+- Dateitransfers werden per SHA256 verifiziert
+- Zugriffsbeschränkungen über Rollen und Berechtigungen
+- Minimal notwendige App‑Permissions (Netzwerk, optional Speicherzugriff)
+
+## Härtungsmaßnahmen
+
+```bash
+sudo ufw default deny incoming
+sudo ufw default allow outgoing
+sudo ufw allow 3000/tcp   # Signaling Server
+sudo ufw allow 3478/udp  # STUN/TURN
+```
+
+AppArmor-Profile und systemd‑Sandboxing findest du im Verzeichnis `security/`.
+
+## Meldung von Schwachstellen
+
+Bitte melde Sicherheitslücken vertraulich per E‑Mail an `security@smoldesk.example`. Der PGP‑Schlüssel befindet sich im Archiv.

--- a/docs/development/setup-android.md
+++ b/docs/development/setup-android.md
@@ -1,0 +1,33 @@
+---
+title: Android Setup
+description: Anleitung zur Einrichtung der Android-Umgebung für SmolDesk Mobile
+---
+
+Diese Anleitung beschreibt die grundlegenden Schritte, um SmolDesk Mobile unter Android zu entwickeln und zu testen. Eine Übersicht der App-Funktionen findest du in [../usage/viewer.md](../usage/viewer.md).
+
+## Voraussetzungen
+
+- Node.js 18 oder neuer
+- Android Studio mit aktuellem Android SDK
+- Java JDK (mindestens Version 11)
+- React‑Native CLI (`npx react-native`)
+
+## Installation
+
+1. Repository klonen und Abhängigkeiten installieren:
+   ```bash
+   npm install
+   ```
+2. Android-Gerät oder Emulator vorbereiten und das Projekt starten:
+   ```bash
+   npx react-native run-android
+   # oder
+   npm run android
+   ```
+3. Für einen signierten Release‑Build:
+   ```bash
+   cd android
+   ./gradlew assembleRelease
+   ```
+
+Weitere Hinweise zum Einsatz der App findest du in der [SmolDesk Mobile Dokumentation](../development/Smodesk-Mobile.md).

--- a/docs/development/setup-ios.md
+++ b/docs/development/setup-ios.md
@@ -1,0 +1,32 @@
+---
+title: iOS Setup
+description: Anleitung zur Einrichtung der iOS-Umgebung für SmolDesk Mobile
+---
+
+Diese Anleitung zeigt die wichtigsten Schritte, um SmolDesk Mobile auf iOS zu entwickeln. Hinweise zur Bedienung findest du auch im [Viewer Guide](../usage/viewer.md).
+
+## Voraussetzungen
+
+- macOS mit aktuellem Xcode
+- Node.js 18+
+- CocoaPods (für native Abhängigkeiten)
+
+## Installation
+
+1. Abhängigkeiten installieren und Pods einrichten:
+   ```bash
+   npm install
+   cd ios
+   pod install
+   cd ..
+   ```
+2. Die App im Simulator oder auf einem Gerät starten:
+   ```bash
+   npx react-native run-ios
+   # oder
+   npm run ios
+   ```
+3. Release‑Build über Xcode erstellen:
+   - In Xcode `Product > Archive` wählen und das Archiv hochladen
+
+Weitere Details zur Portierung findest du in der [SmolDesk Mobile Planung](../development/Smodesk-Mobile.md).


### PR DESCRIPTION
## Summary
- migrate setup and security docs
- add new development guides
- archive older setup files

## Testing
- `npm test` *(fails: vitest not found)*
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: `glib-2.0` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bb02b125c8324baacfe5acfd73532