### PR TITLE
🧪 Migrate test plans and logs to docs/development/

### DIFF
--- a/docs/archive/old_docs/Smodesk-Mobile-Testplan.md
+++ b/docs/archive/old_docs/Smodesk-Mobile-Testplan.md
@@ -1,3 +1,6 @@
+⚠️ Diese Datei wurde archiviert. Die aktuelle Version befindet sich unter `docs/development/testplan.md`
+
+
 # Testplan für SmolDesk Mobile
 
 1. **Unit Tests** mit Jest für Hilfsfunktionen und Services

--- a/docs/archive/old_docs/Smodesk-Mobile-Testprotokoll.md
+++ b/docs/archive/old_docs/Smodesk-Mobile-Testprotokoll.md
@@ -1,3 +1,5 @@
+⚠️ Diese Datei wurde archiviert. Die aktuelle Version befindet sich unter `docs/development/testprotokoll.md`
+
 # Testprotokoll SmolDesk Mobile
 
 Die folgenden Szenarien werden vor einem Release manuell getestet. Jede Checkbox sollte nach erfolgreichem Test abgehakt werden.

--- a/docs/development/testplan.md
+++ b/docs/development/testplan.md
@@ -1,0 +1,33 @@
+---
+title: Testplan SmolDesk Mobile
+description: Teststrategie und Testfälle für die mobile App
+---
+
+# Einleitung
+Dieser Testplan definiert Vorgehen und Umgebungen zur Prüfung von SmolDesk Mobile. Er ergänzt die [allgemeine Teststrategie](../testing/strategy.md) und dient als Grundlage für das [Testprotokoll](./testprotokoll.md).
+
+## Testumgebungen
+- Android-Emulator und reale Geräte gemäß [Setup-Anleitung](./setup-android.md)
+- iOS-Simulator gemäß [Setup-Anleitung](./setup-ios.md)
+- Lokale Node-Umgebung für Unit- und Integrationstests
+
+## Testarten
+- **Unit Tests** via Vitest/Jest
+- **Integrationstests** mit gemockten WebRTC-Komponenten
+- **Manuelle Szenarien** auf Endgeräten
+- **End-to-End-Tests** optional mit Playwright oder Detox
+
+## Testfälle
+1. Verbindung zu einem Linux-Host herstellen
+2. Gestenbedienung: Pinch-Zoom, Drag, Rechtsklick (Zwei-Finger-Tap)
+3. [Clipboard-Synchronisation](../usage/clipboard.md) zwischen Host und Mobilgerät
+4. Login- und Logout-Prozess über OAuth2 inklusive Token-Refresh
+5. Tokenweitergabe und -prüfung beim [Signaling](./mobile-signaling.md)
+6. Verschlüsselte und unverschlüsselte Dateiübertragungen – siehe [Dateien senden und empfangen](../usage/files.md)
+7. Monitorwechsel bei mehreren Bildschirmen – siehe [Monitorsteuerung](../usage/monitors.md)
+8. Umschalten zwischen Dark- und Light-Mode
+9. Stabilität bei Hintergrundbetrieb und Rückkehr zur App
+10. Responsives Layout auf kleinen Phones und Tablets im [Viewer](../usage/viewer.md)
+
+## Ergebnisse
+Alle Resultate und offene Punkte werden im [Testprotokoll](./testprotokoll.md) festgehalten.

--- a/docs/development/testprotokoll.md
+++ b/docs/development/testprotokoll.md
@@ -1,0 +1,21 @@
+---
+title: Testprotokoll SmolDesk Mobile
+description: Ergebnisse manuell durchgeführter Tests
+---
+
+# Einleitung
+Dieses Protokoll hält den Status der im [Testplan](./testplan.md) definierten Fälle fest. Jede Zeile wird nach erfolgreichem Test abgehakt und eventuelle Fehler werden notiert.
+
+## Testergebnisse
+- [ ] Verbindung
+- [ ] Remote-Stream
+- [ ] Maussteuerung
+- [ ] Tastatur
+- [ ] Clipboard
+- [ ] Dateiübertragung
+- [ ] Multi-Monitor
+- [ ] Darkmode
+- [ ] Hintergrundverhalten
+
+## Offene Punkte
+Noch keine bekannten Fehler.


### PR DESCRIPTION
## Summary
- migrate old test docs to docs/development
- archive historical testplan and testprotokoll

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686be1be9c4c83248d66cce811d908ed