### PR TITLE
🚀 Migrate release documentation to docs/release/

### DIFF
--- a/docs/archive/old_docs/SmolDesk-Mobile-PlayStore.md
+++ b/docs/archive/old_docs/SmolDesk-Mobile-PlayStore.md
@@ -1,3 +1,5 @@
+⚠️ Diese Datei wurde archiviert. Die aktuelle Version befindet sich unter `docs/release/playstore.md`
+
 # SmolDesk Mobile – Play Store Informationen
 
 ## Kurzbeschreibung

--- a/docs/archive/old_docs/SmolDesk-Mobile-Release.md
+++ b/docs/archive/old_docs/SmolDesk-Mobile-Release.md
@@ -1,3 +1,5 @@
+⚠️ Diese Datei wurde archiviert. Die aktuelle Version befindet sich unter `docs/release/release-process.md`
+
 # SmolDesk Mobile Release Checkliste
 
 ## Vorbereitung

--- a/docs/archive/old_docs/SmolDesk-Mobile-StoreText.json
+++ b/docs/archive/old_docs/SmolDesk-Mobile-StoreText.json
@@ -1,3 +1,5 @@
+⚠️ Diese Datei wurde archiviert. Die aktuelle Version befindet sich unter `docs/release/playstore.md`
+
 {
   "shortDescription": "Fernzugriff auf deinen Linux-Desktop per WebRTC",
   "fullDescription": "SmolDesk Mobile verbindet dein Telefon direkt mit deinem Linux-PC. Sichere Peer-to-Peer-Verbindung, Multi-Monitor und Dateiübertragung inklusive.",

--- a/docs/release/changelog.md
+++ b/docs/release/changelog.md
@@ -1,0 +1,10 @@
+---
+title: Changelog
+description: Versionsübersicht von SmolDesk Mobile
+---
+
+| Version | Datum | Änderungen |
+|---------|-------|--------------|
+| v1.0.0-beta | 2025-01-01 | Erste Beta-Version |
+
+Weitere Releases werden hier eingetragen.

--- a/docs/release/playstore.md
+++ b/docs/release/playstore.md
@@ -1,0 +1,35 @@
+---
+title: Android-Veröffentlichung
+description: Anleitung zur Bereitstellung von SmolDesk Mobile im Google Play Store
+---
+
+Diese Anleitung beschreibt, wie SmolDesk Mobile für Android veröffentlicht wird. Für die Einrichtung der Entwicklungsumgebung siehe [../development/setup-android.md](../development/setup-android.md).
+
+## Play Store Listing
+
+### Kurzbeschreibung
+Fernzugriff auf deinen Linux-Desktop per WebRTC
+
+### Ausführliche Beschreibung
+SmolDesk Mobile verbindet dein Telefon direkt mit deinem Linux-PC. Sichere Peer-to-Peer-Verbindung, Multi-Monitor und Dateiübertragung inklusive.
+
+### What's New
+Erste Beta-Version
+
+Weitere Hinweise zur Datenschutzerklärung finden sich unter [../public/privacy-policy.html](../public/privacy-policy.html).
+
+## Release-Build erstellen
+
+1. Version in `app/build.gradle` erhöhen
+2. Release-Build erzeugen
+
+```bash
+cd android
+./gradlew assembleRelease
+./gradlew bundleRelease
+```
+
+3. Die entstandene `.aab`-Datei signieren und in der Google Play Console hochladen
+4. Tester über "Internal testing" einladen und Feedback einholen
+
+Die detaillierte Release-Abfolge ist im [Release-Prozess](./release-process.md) beschrieben.

--- a/docs/release/release-process.md
+++ b/docs/release/release-process.md
@@ -1,0 +1,21 @@
+---
+title: Release-Prozess
+description: Manuelle Schritte zum Bauen und Veröffentlichen von SmolDesk Mobile
+---
+
+Dieser Leitfaden führt durch den gesamten Veröffentlichungsablauf für Android und iOS.
+
+1. **Version anheben**
+   - Android: `app/build.gradle`
+   - iOS: Xcode-Projekt
+2. **Changelog aktualisieren**: [changelog.md](./changelog.md)
+3. **Builds erstellen**
+   - Android siehe [playstore.md](./playstore.md)
+   - iOS siehe [testflight.md](./testflight.md)
+4. **Uploads durchführen**
+   - Google Play Console (Internal Testing / Produktion)
+   - App Store Connect / TestFlight
+5. **Freigabe**
+   - Nach bestandenen Tests Release in den Stores freischalten
+
+Für die Einrichtung der Entwicklungsumgebungen verweise auf [../development/setup-android.md](../development/setup-android.md) und [../development/setup-ios.md](../development/setup-ios.md).

--- a/docs/release/testflight.md
+++ b/docs/release/testflight.md
@@ -1,0 +1,17 @@
+---
+title: TestFlight
+description: Anleitung für iOS-Tests von SmolDesk über TestFlight
+---
+
+Diese Anleitung beschreibt den Beta-Test von SmolDesk Mobile auf iOS. Hinweise zur Einrichtung findest du unter [../development/setup-ios.md](../development/setup-ios.md).
+
+## Voraussetzungen
+- Aktuelles Xcode
+- Apple Developer Account
+
+## Schritte
+1. In Xcode `Product > Archive` ausführen
+2. Über den Organizer oder Transporter hochladen
+3. Interne Tester in App Store Connect einladen
+
+Weitere Schritte für die finale Veröffentlichung sind im [Release-Prozess](./release-process.md) beschrieben.


### PR DESCRIPTION
## Summary
- consolidate release docs under docs/release
- add Play Store, TestFlight, release process and changelog guides
- archive old release files

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686bf3e0ed748324b04a93df671abba4