### PR TITLE
🧩 Add feature and component documentation under docs/features/

### DIFF
--- a/docs/features/clipboard.md
+++ b/docs/features/clipboard.md
@@ -1,0 +1,26 @@
+---
+title: Zwischenablage-Sync
+description: Überträgt Texte und Bilder zwischen Host und Client.
+---
+
+## Funktion & Zweck
+Die Clipboard-Funktion gleicht Inhalte automatisch ab und speichert eine Historie lokaler Einträge.
+
+## UX-Verhalten / Interface
+- Desktop: Text und Bilder (PNG, JPEG, GIF) werden übernommen
+- HTML wird als reiner Text gesendet
+- Auf Mobilgeräten ist derzeit nur Text unterstützt
+
+Mehr zur Bedienung in [../usage/clipboard.md](../usage/clipboard.md).
+
+## Technische Architektur / Datenfluss
+- Komponente [`ClipboardSync`](../docs/components/ClipboardSync.md) lauscht über Tauri auf lokale Änderungen
+- Über den WebRTC-Datenkanal werden Einträge an den Peer übertragen
+- Standardlimit: 10 MB pro Eintrag, anpassbar über die Konfiguration
+
+## Sicherheit & Einschränkungen
+- Synchronisation kann in den Einstellungen deaktiviert werden
+- Große oder unbekannte Dateitypen werden gefiltert
+
+## Verweise
+- Entwicklerhinweise unter [../development/security.md](../development/security.md)

--- a/docs/features/files.md
+++ b/docs/features/files.md
@@ -1,0 +1,28 @@
+---
+title: Dateiübertragung
+description: Sendet Dateien sicher über den WebRTC-Datenkanal.
+---
+
+## Funktion & Zweck
+Über den eingebauten Dateitransfer können Dateien zwischen Client und Host ausgetauscht werden.
+
+## UX-Verhalten / Interface
+- Dateien per Drag & Drop ablegen oder **Datei senden** auswählen
+- Mehrfachübertragungen sowie Pausieren/Fortsetzen werden unterstützt
+- Standardlimit 100 MB pro Datei
+- Mobile: Versand über Dokument-Picker, Empfang im Download-Ordner
+
+Details zur Nutzung unter [../usage/files.md](../usage/files.md).
+
+## Technische Architektur / Datenfluss
+- `FileTransfer`-Komponente arbeitet mit dem WebRTC-Datenkanal
+- Blöcke mit 64 KB Größe werden sequentiell übertragen
+- Fortschritt wird lokal gespeichert, um Wiederaufnahme zu ermöglichen
+
+## Sicherheit & Einschränkungen
+- Übertragene Dateien werden per SHA256 verifiziert
+- Große Dateien können Verbindungslatenzen erhöhen
+
+## Verweise
+- Komponenten-Dokumentation: [FileTransfer](../docs/components/FileTransfer.md)
+- Sicherheitshinweise unter [../development/security.md](../development/security.md)

--- a/docs/features/monitors.md
+++ b/docs/features/monitors.md
@@ -1,0 +1,26 @@
+---
+title: Multi-Monitor-Unterstützung
+description: Wechsel zwischen mehreren Bildschirmen im laufenden Betrieb.
+---
+
+## Funktion & Zweck
+SmolDesk erkennt verfügbare Monitore und erlaubt das Umschalten während einer Sitzung.
+
+## UX-Verhalten / Interface
+- Alle Monitore werden im Host-Tab angezeigt
+- Umschalten erfolgt über einen Dialog im Viewer
+- Jeder Bildschirm kann eigene Auflösung und Bildrate haben
+
+Siehe [../usage/monitors.md](../usage/monitors.md) für Nutzerhinweise.
+
+## Technische Architektur / Datenfluss
+- Monitorinformationen werden vom Backend per Tauri-IPC geliefert
+- `ConnectionManager` fordert bei einem Wechsel einen neuen Stream an
+- RemoteScreen passt Größe und Skalierung automatisch an
+
+## Sicherheit & Einschränkungen
+- Bei sehr hohen Auflösungen steigt die Bandbreite deutlich an
+- Nicht jeder Monitor unterstützt Hardwarebeschleunigung
+
+## Verweise
+- Architekturdetails unter [../docs/architecture.md](../docs/architecture.md)

--- a/docs/features/remote.md
+++ b/docs/features/remote.md
@@ -1,0 +1,29 @@
+---
+title: Remote-Verbindung
+description: Steuere den Bildschirm über eine WebRTC-Verbindung mit Maus und Tastatur.
+---
+
+## Funktion & Zweck
+SmolDesk ermöglicht die Fernsteuerung eines Linux-Hosts. Über eine Peer-to-Peer-Verbindung werden Bildschirm und Eingaben in Echtzeit übertragen.
+
+## UX-Verhalten / Interface
+- Verbindung per Raum-Code im **View**-Tab aufbauen
+- **Input On/Off** zum Pausieren der Steuerung
+- Vollbildmodus via `F11` oder Icon
+- Mobile unterstützt Touch-Gesten für Klicks und Scrollen
+
+Weitere Details unter [../usage/viewer.md](../usage/viewer.md).
+
+## Technische Architektur / Datenfluss
+- `ConnectionManager` stellt die WebRTC-Verbindung her und leitet Streams an `RemoteScreen` weiter
+- Eingaben werden über denselben Kanal zurückgesendet
+- Architekturüberblick siehe [../docs/architecture.md](../docs/architecture.md)
+
+## Sicherheit & Einschränkungen
+- Authentifizierung mit JWT-Token
+- Datenkanal- und Transportverschlüsselung per DTLS/AES
+- Verbindung kann bei schwacher Netzqualität abbrechen
+
+## Verweise
+- Komponenten: [ConnectionManager](../docs/components/ConnectionManager.md), [RemoteScreen](../docs/components/RemoteScreen.md)
+- Entwicklertipps unter [../development/dev-tools.md](../development/dev-tools.md)

--- a/docs/features/security.md
+++ b/docs/features/security.md
@@ -1,0 +1,26 @@
+---
+title: Sicherheit
+description: Übersicht der wichtigsten Sicherheitsmechanismen von SmolDesk.
+---
+
+## Funktion & Zweck
+SmolDesk schützt Verbindungen und Daten durch mehrere Ebenen.
+
+## UX-Verhalten / Interface
+- Verbindungen zu geschützten Räumen erfordern ein Passwort
+- Sicherheitsoptionen können im Einstellungsdialog konfiguriert werden
+
+Weitere Hinweise zur Nutzung im [Viewer Guide](../usage/viewer.md).
+
+## Technische Architektur / Datenfluss
+- DTLS 1.2 sichert Transportebene, Datenkanäle werden zusätzlich per AES verschlüsselt
+- JWT-Authentifizierung und optionaler HMAC-Schutz für Nachrichten
+- Dateitransfers erhalten SHA256-Checksummen
+
+## Sicherheit & Einschränkungen
+- Minimal notwendige App-Berechtigungen
+- UFW- und AppArmor-Beispiele siehe [../development/security.md](../development/security.md)
+- Schwachstellen können vertraulich gemeldet werden
+
+## Verweise
+- Pentest-Skript unter [../../security/pentest/automated_security_scan.py](../../security/pentest/automated_security_scan.py)


### PR DESCRIPTION
## Summary
- add documentation pages for remote control, clipboard sync, file transfer, multi-monitor and security

## Testing
- `npx vitest run` *(fails: cannot find package 'vitest')*
- `cargo test` in `src-tauri` *(fails: system library `glib-2.0` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bfd9e11d48324a49d17b042335bb7