### PR TITLE
🧮 Add technical component reference under docs/components/

### DIFF
--- a/docs/components/Button.md
+++ b/docs/components/Button.md
@@ -1,0 +1,18 @@
+---
+title: Button
+description: 
+---
+
+## Function
+TBD
+
+## Props
+
+| Name | Type |
+| --- | --- |
+| `label` | `string` |
+| `onClick` | `() => void` |
+
+## Source
+
+[src/components/Button.tsx](/src/components/Button.tsx)

--- a/docs/components/ClipboardSync.md
+++ b/docs/components/ClipboardSync.md
@@ -1,0 +1,27 @@
+---
+title: ClipboardSync
+description: src/components/ClipboardSync.tsx - Frontend-Komponente für Zwischenablage-Synchronisation
+---
+
+## Function
+src/components/ClipboardSync.tsx - Frontend-Komponente für Zwischenablage-Synchronisation
+
+## Props
+
+| Name | Type |
+| --- | --- |
+| `webrtcConnection` | `WebRTCConnection` |
+| `onSync` | `(entry: ClipboardEntry) => void` |
+| `onError` | `(error: string) => void` |
+
+## Used Hooks
+
+`useState`, `useEffect`, `useRef`, `useCallback`
+
+## Related Features
+
+- [Feature Documentation](../features/clipboard.md)
+
+## Source
+
+[src/components/ClipboardSync.tsx](/src/components/ClipboardSync.tsx)

--- a/docs/components/ConnectionManager.md
+++ b/docs/components/ConnectionManager.md
@@ -1,0 +1,30 @@
+---
+title: ConnectionManager
+description: src/components/ConnectionManager.tsx
+---
+
+## Function
+src/components/ConnectionManager.tsx
+
+## Props
+
+| Name | Type |
+| --- | --- |
+| `onConnected` | `(peerId: string) => void` |
+| `onDisconnected` | `() => void` |
+| `onStream` | `(stream: MediaStream) => void` |
+| `onError` | `(error: Error) => void` |
+| `signalingServer` | `string` |
+| `autoConnect` | `boolean` |
+
+## Used Hooks
+
+`useState`, `useEffect`, `useCallback`
+
+## Related Features
+
+- [Feature Documentation](../features/remote.md)
+
+## Source
+
+[src/components/ConnectionManager.tsx](/src/components/ConnectionManager.tsx)

--- a/docs/components/FileTransfer.md
+++ b/docs/components/FileTransfer.md
@@ -1,0 +1,27 @@
+---
+title: FileTransfer
+description: src/components/FileTransfer.tsx - File Transfer UI Component
+---
+
+## Function
+src/components/FileTransfer.tsx - File Transfer UI Component
+
+## Props
+
+| Name | Type |
+| --- | --- |
+| `webrtcConnection` | `WebRTCConnection` |
+| `onTransferComplete` | `(transferId: string) => void` |
+| `onError` | `(error: string) => void` |
+
+## Used Hooks
+
+`useState`, `useEffect`, `useRef`, `useCallback`
+
+## Related Features
+
+- [Feature Documentation](../features/files.md)
+
+## Source
+
+[src/components/FileTransfer.tsx](/src/components/FileTransfer.tsx)

--- a/docs/components/RemoteScreen.md
+++ b/docs/components/RemoteScreen.md
@@ -1,0 +1,28 @@
+---
+title: RemoteScreen
+description: src/components/RemoteScreen.tsx
+---
+
+## Function
+src/components/RemoteScreen.tsx
+
+## Props
+
+| Name | Type |
+| --- | --- |
+| `stream` | `MediaStream` |
+| `isConnected` | `boolean` |
+| `inputEnabled` | `boolean` |
+| `onInputToggle` | `(enabled: boolean) => void` |
+
+## Used Hooks
+
+`useState`, `useEffect`, `useRef`, `useCallback`
+
+## Related Features
+
+- [Feature Documentation](../features/remote.md)
+
+## Source
+
+[src/components/RemoteScreen.tsx](/src/components/RemoteScreen.tsx)

--- a/docs/components/clipboard.md
+++ b/docs/components/clipboard.md
@@ -1,0 +1,27 @@
+---
+title: clipboard
+description: src-tauri/src/clipboard/mod.rs - Zwischenablage-Synchronisation System
+---
+
+## Public Structs
+- `ClipboardManager`
+
+## Public Functions
+- `new`
+- `start_monitoring`
+- `stop_monitoring`
+- `get_text`
+- `set_text`
+- `get_image`
+- `set_image`
+- `get_history`
+- `clear_history`
+- `add_change_callback`
+- `export_entry`
+- `import_entry`
+- `sync_remote_entry`
+- `create_sync_entry`
+
+## Source
+
+[src-tauri/src/clipboard/mod.rs](/src-tauri/src/clipboard/mod.rs)

--- a/docs/components/file_transfer.md
+++ b/docs/components/file_transfer.md
@@ -1,0 +1,18 @@
+---
+title: file_transfer
+description: src-tauri/src/file_transfer/mod.rs - Dateiübertragungssystem für SmolDesk
+---
+
+## Public Structs
+- `FileTransferManager`
+
+## Public Functions
+- `new`
+- `set_event_sender`
+- `get_transfer_info`
+- `get_active_transfers`
+- `get_stats`
+
+## Source
+
+[src-tauri/src/file_transfer/mod.rs](/src-tauri/src/file_transfer/mod.rs)

--- a/docs/components/index.md
+++ b/docs/components/index.md
@@ -1,0 +1,14 @@
+---
+title: Components Overview
+description: Reference of all UI components
+---
+
+- [Button](Button.md) - 
+- [ClipboardSync](ClipboardSync.md) - src/components/ClipboardSync.tsx - Frontend-Komponente für Zwischenablage-Synchronisation
+- [ConnectionManager](ConnectionManager.md) - src/components/ConnectionManager.tsx
+- [FileTransfer](FileTransfer.md) - src/components/FileTransfer.tsx - File Transfer UI Component
+- [RemoteScreen](RemoteScreen.md) - src/components/RemoteScreen.tsx
+- [clipboard](clipboard.md) - src-tauri/src/clipboard/mod.rs - Zwischenablage-Synchronisation System
+- [file_transfer](file_transfer.md) - src-tauri/src/file_transfer/mod.rs - Dateiübertragungssystem für SmolDesk
+- [input_forwarding](input_forwarding.md) - mod.rs - Main module definition for input forwarding system
+- [screen_capture](screen_capture.md) - screen_capture/mod.rs - Main module that exports public APIs

--- a/docs/components/input_forwarding.md
+++ b/docs/components/input_forwarding.md
@@ -1,0 +1,9 @@
+---
+title: input_forwarding
+description: mod.rs - Main module definition for input forwarding system
+---
+
+
+## Source
+
+[src-tauri/src/input_forwarding/mod.rs](/src-tauri/src/input_forwarding/mod.rs)

--- a/docs/components/screen_capture.md
+++ b/docs/components/screen_capture.md
@@ -1,0 +1,9 @@
+---
+title: screen_capture
+description: screen_capture/mod.rs - Main module that exports public APIs
+---
+
+
+## Source
+
+[src-tauri/src/screen_capture/mod.rs](/src-tauri/src/screen_capture/mod.rs)

--- a/scripts/docs-generator.js
+++ b/scripts/docs-generator.js
@@ -1,0 +1,119 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+const COMPONENTS_DIR = path.join('src', 'components');
+const DOCS_DIR = path.join('docs', 'components');
+
+async function getTsFiles() {
+  const files = await fs.readdir(COMPONENTS_DIR);
+  return files.filter(f => f.endsWith('.tsx') && !f.includes('.stories') && !f.includes('.demo'));
+}
+
+function extractFirstComment(text) {
+  const match = text.match(/\/\/\s*(.*)/);
+  return match ? match[1].trim() : '';
+}
+
+function extractProps(text) {
+  const result = [];
+  const match = text.match(/interface\s+\w*Props\s*{([\s\S]*?)}/);
+  if (!match) return result;
+  const body = match[1];
+  const propRegex = /\s*(\w+)\??:\s*([^;]+)/g;
+  let m;
+  while ((m = propRegex.exec(body)) !== null) {
+    result.push({ name: m[1], type: m[2].trim() });
+  }
+  return result;
+}
+
+function extractHooks(text) {
+  const hooks = ['useState','useEffect','useRef','useCallback','useMemo'];
+  return hooks.filter(h => text.includes(h));
+}
+
+const featureLinks = {
+  ClipboardSync: '../features/clipboard.md',
+  ConnectionManager: '../features/remote.md',
+  RemoteScreen: '../features/remote.md',
+  FileTransfer: '../features/files.md',
+};
+
+function createDoc(name, desc, props, hooks, sourcePath) {
+  let md = `---\ntitle: ${name}\ndescription: ${desc}\n---\n\n`;
+  md += `## Function\n${desc || 'TBD'}\n\n`;
+  if (props.length) {
+    md += '## Props\n\n| Name | Type |\n| --- | --- |\n';
+    for (const p of props) {
+      md += `| \`${p.name}\` | \`${p.type}\` |\n`;
+    }
+  }
+  if (hooks.length) {
+    md += '\n## Used Hooks\n\n';
+    md += hooks.map(h => `\`${h}\``).join(', ');
+    md += '\n';
+  }
+  if (featureLinks[name]) {
+    md += `\n## Related Features\n\n- [Feature Documentation](${featureLinks[name]})\n`;
+  }
+  md += `\n## Source\n\n[${sourcePath}](/${sourcePath})\n`;
+  return md;
+}
+
+async function main() {
+  await fs.mkdir(DOCS_DIR, { recursive: true });
+  const tsFiles = await getTsFiles();
+  const indexEntries = [];
+
+  // Process React components
+  for (const file of tsFiles) {
+    const filePath = path.join(COMPONENTS_DIR, file);
+    const text = await fs.readFile(filePath, 'utf8');
+    const name = path.basename(file, '.tsx');
+    const desc = extractFirstComment(text);
+    const props = extractProps(text);
+    const hooks = extractHooks(text);
+    const doc = createDoc(name, desc, props, hooks, filePath);
+    await fs.writeFile(path.join(DOCS_DIR, `${name}.md`), doc, 'utf8');
+    indexEntries.push({ name, desc });
+  }
+
+  // Process Rust modules
+  const rustRoot = path.join('src-tauri', 'src');
+  const rustModules = await fs.readdir(rustRoot);
+  for (const mod of rustModules) {
+    const modFile = path.join(rustRoot, mod, 'mod.rs');
+    try {
+      const text = await fs.readFile(modFile, 'utf8');
+      const descMatch = text.match(/\/\/\s*(.*)/);
+      const desc = descMatch ? descMatch[1].trim() : '';
+      const structs = Array.from(text.matchAll(/pub struct (\w+)/g)).map(m => m[1]);
+      const fns = Array.from(text.matchAll(/pub fn (\w+)/g)).map(m => m[1]);
+      let md = `---\ntitle: ${mod}\ndescription: ${desc}\n---\n\n`;
+      if (structs.length) {
+        md += '## Public Structs\n';
+        for (const s of structs) md += `- \`${s}\`\n`;
+      }
+      if (fns.length) {
+        md += '\n## Public Functions\n';
+        for (const f of fns) md += `- \`${f}\`\n`;
+      }
+      md += `\n## Source\n\n[${modFile}](/${modFile})\n`;
+      await fs.writeFile(path.join(DOCS_DIR, `${mod}.md`), md, 'utf8');
+      indexEntries.push({ name: mod, desc });
+    } catch (err) {
+      // ignore missing mod.rs
+    }
+  }
+
+  let indexMd = `---\ntitle: Components Overview\ndescription: Reference of all UI components\n---\n\n`;
+  for (const entry of indexEntries) {
+    indexMd += `- [${entry.name}](${entry.name}.md) - ${entry.desc}\n`;
+  }
+  await fs.writeFile(path.join(DOCS_DIR, 'index.md'), indexMd, 'utf8');
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- generate technical documentation for all components
- add script `docs-generator.js` to build docs from `src/components` and `src-tauri`

## Testing
- `npm run test:run`


------
https://chatgpt.com/codex/tasks/task_e_686caef9dde8832484d970a2781b1bc2