### PR TITLE
📡 Add API reference documentation under docs/api/

### DIFF
--- a/docs/api/cli-commands.md
+++ b/docs/api/cli-commands.md
@@ -1,0 +1,30 @@
+---
+title: CLI Commands
+description: Nützliche Kommandozeilenaufrufe für Entwicklung und Betrieb
+---
+
+Im Projekt existieren mehrere npm-Skripte sowie Tauri- und Node-basierte Befehle. Die wichtigsten sind nachfolgend aufgeführt.
+
+## npm scripts
+
+| Befehl | Zweck |
+|--------|-------|
+| `npm run dev` | Startet das React-Frontend im Entwicklungsmodus. |
+| `npm run tauri` | Erstellt die native Anwendung über die Tauri-Toolchain. |
+| `npm run build` | Erstellt einen Produktionsbuild des Frontends. |
+| `npm run signaling-server` | Startet den Signaling-Server (WebSocket). |
+| `npm run test` | Führt die Vitest-Testsuite aus. |
+
+Weitere Skripte sind in der `package.json` dokumentiert.
+
+## Signaling Server
+
+Im Unterordner `signaling-server` stehen zusätzliche Befehle zur Verfügung:
+
+| Befehl | Beschreibung |
+|--------|--------------|
+| `npm start` | Startet den Server auf Port 3000. |
+| `npm run dev` | Startet den Server mit automatischem Reload über nodemon. |
+| `npm run docker:build` | Baut ein Docker-Image des Servers. |
+
+Die genauen Optionen können der jeweiligen `package.json` entnommen werden.

--- a/docs/api/http-endpoints.md
+++ b/docs/api/http-endpoints.md
@@ -1,0 +1,16 @@
+---
+title: HTTP Endpoints
+description: Signaling-Server und sonstige HTTP-Schnittstellen
+---
+
+Der mitgelieferte Signaling-Server stellt nur einen sehr kleinen HTTP-Teil bereit. Hauptkommunikationsweg ist eine WebSocket-Verbindung, die ebenfalls auf Port `3000` läuft.
+
+## Endpoints
+
+| Methode | Pfad | Beschreibung |
+|---------|------|--------------|
+| `GET` | `/` | Gibt den Text `SmolDesk Signaling Server` zurück und dient als einfache Funktionsprobe. |
+
+Weitere REST- oder JSON-APIs sind aktuell nicht implementiert. Für die Peer-Verbindung wird stattdessen das unten beschriebene WebSocket-Protokoll genutzt.
+
+Siehe auch [Protocols](protocols.md) für Details zu den Nachrichtentypen.

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,0 +1,11 @@
+---
+title: API Übersicht
+description: Sammelindex aller verfügbaren Schnittstellen von SmolDesk
+---
+
+Diese Sektion fasst die verschiedenen Programmschnittstellen der Anwendung zusammen.
+
+- [IPC Interface](ipc-interface.md)
+- [HTTP Endpoints](http-endpoints.md)
+- [CLI Commands](cli-commands.md)
+- [Protocols](protocols.md)

--- a/docs/api/ipc-interface.md
+++ b/docs/api/ipc-interface.md
@@ -1,0 +1,37 @@
+---
+title: IPC Interface
+description: Übersicht der in SmolDesk verfügbaren Tauri-Kommandos
+---
+
+SmolDesk verwendet Tauri zur Kommunikation zwischen Frontend (React) und Backend (Rust). Die folgenden Befehle können über `invoke` aufgerufen werden.
+
+## Commands
+
+| Command | Parameters | Returns | Zugehörige Features |
+|--------|------------|---------|--------------------|
+| `get_display_server` | – | `String` | [Remote](../features/remote.md) |
+| `get_monitors` | – | `Result<Vec<MonitorInfo>, String>` | [Monitors](../features/monitors.md) |
+| `start_capture` | `monitorIndex: usize`, `config: ScreenCaptureConfig` | `Result<(), String>` | [Remote](../features/remote.md) |
+| `stop_capture` | – | `Result<(), String>` | [Remote](../features/remote.md) |
+| `send_input_event` | `event: InputEvent` | `Result<(), String>` | [Remote](../features/remote.md) |
+| `set_input_enabled` | `enabled: bool` | `Result<(), String>` | [Remote](../features/remote.md) |
+| `configure_input_forwarding` | `config: InputForwardingConfig` | `Result<(), String>` | [Monitors](../features/monitors.md) |
+| `get_video_codecs` | – | `Vec<String>` | [Remote](../features/remote.md) |
+| `get_hardware_acceleration_options` | – | `Vec<String>` | [Remote](../features/remote.md) |
+| `get_clipboard_text` | – | `Result<String, String>` | [Clipboard](../features/clipboard.md) |
+| `set_clipboard_text` | `text: String` | `Result<(), String>` | [Clipboard](../features/clipboard.md) |
+| `initialize_security` | `secretKey: String` | `Result<(), String>` | [Security](../features/security.md) |
+
+Weitere Kommandos wie Dateiübertragung oder OAuth befinden sich in der Entwicklung und sind aktuell als experimentell gekennzeichnet.
+
+### Beispiel
+
+```ts
+import { invoke } from '@tauri-apps/api/tauri'
+
+await invoke('start_capture', { monitorIndex: 0, config: { fps: 30 } })
+```
+
+## Events
+
+Das Backend sendet Ereignisse über Tauri's Event-System. Relevante Events sind unter anderem `transfer-started`, `transfer-progress`, `transfer-completed` sowie `clipboard-changed`. Weitere Eventnamen finden sich in den jeweiligen Komponenten.

--- a/docs/api/protocols.md
+++ b/docs/api/protocols.md
@@ -1,0 +1,34 @@
+---
+title: Protocols
+description: WebSocket-Nachrichten des Signaling-Servers
+---
+
+Die Verbindung zwischen den Peers wird über einen WebSocket-Server vermittelt. Nach dem Verbindungsaufbau tauschen Client und Server JSON-Nachrichten mit einem `type` Feld aus.
+
+## Nachrichten vom Server
+
+| Typ | Inhalt |
+|-----|--------|
+| `welcome` | Enthält `clientId` und ein zufällig generiertes `token`. |
+| `room-created` | Bestätigung nach `create-room` mit der vergebenen `roomId`. |
+| `room-joined` | Bestätigung nach `join-room` sowie Liste vorhandener Peers. |
+| `peer-joined` | Ein neuer Peer ist dem Raum beigetreten. |
+| `peer-left` | Ein Peer hat den Raum verlassen. |
+| `peer-disconnected` | Verbindung zu einem Peer ging verloren. |
+| `room-left` | Bestätigung nach Verlassen eines Raums. |
+| `ice-candidate`, `offer`, `answer` | Weiterleitung der jeweiligen WebRTC-Daten. |
+| `pong` | Antwort auf einen Ping des Clients. |
+
+## Nachrichten vom Client
+
+| Typ | Beschreibung |
+|-----|-------------|
+| `create-room` | Legt einen neuen Raum an. Optional kann eine `roomId` übermittelt werden. |
+| `join-room` | Tritt einem bestehenden Raum bei. |
+| `leave-room` | Verlasse den aktuellen Raum. |
+| `ice-candidate` | Übermittelt ICE-Kandidaten an einen Peer. |
+| `offer` | WebRTC Offer an einen Ziel-Peer. |
+| `answer` | WebRTC Answer an einen Ziel-Peer. |
+| `ping` | Lebenszeichen zur Verbindungsüberwachung. |
+
+Das Protokoll ist textbasiert (JSON) und sieht keine Authentifizierung vor. Sicherheitsfunktionen befinden sich in der [Security](../features/security.md) Komponente.


### PR DESCRIPTION
## Summary
- document IPC, HTTP, CLI and protocol APIs under `docs/api/`
- extend docs generator with API extraction helpers

## Testing
- `npm install`
- `npm run test:run`


------
https://chatgpt.com/codex/tasks/task_e_686cb4ee424083248639f45a25d4515c