### PR TITLE
🛠️ Startseiten-Feature-Komponente für SmolDesk angepasst

### DIFF
--- a/docs/docs-styleguide.md
+++ b/docs/docs-styleguide.md
@@ -132,3 +132,10 @@ Folgende Bereiche gehören nicht zur SmolDesk-Dokumentation und dürfen nicht ü
 - Agenten-Systeme (`docs/agents/`)
 - Docusaurus-Tutorial-Inhalte (`docs/docusaurus/`, `docs/blog/`)
 - Beispielseiten (`src/pages/markdown-page.md`, etc.)
+
+## 🧩 Startseiten-Komponente (HomepageFeatures)
+
+- Datei: docs/src/components/HomepageFeatures/index.tsx
+- Zeigt 3–6 projektrelevante SmolDesk-Funktionen auf der Startseite
+- Klarer, verständlicher Text (Zielgruppe: interessierte Nutzer:innen)
+- Icons oder Emojis zur visuellen Unterstützung

--- a/docs/src/components/HomepageFeatures/index.tsx
+++ b/docs/src/components/HomepageFeatures/index.tsx
@@ -3,51 +3,79 @@ import clsx from 'clsx';
 import Heading from '@theme/Heading';
 import styles from './styles.module.css';
 
+/**
+ * Single card information used on the landing page.
+ * Add more entries to FeatureList below to extend the section.
+ */
 type FeatureItem = {
   title: string;
-  Svg: React.ComponentType<React.ComponentProps<'svg'>>;
+  icon: ReactNode; // Svg component or emoji
   description: ReactNode;
 };
 
 const FeatureList: FeatureItem[] = [
   {
-    title: 'Easy to Use',
-    Svg: require('@site/static/img/undraw_docusaurus_mountain.svg').default,
-    description: (
-      <>
-        ESN_Repo-Template was designed from the ground up to be easily installed and
-        used to get your repository up and running quickly.
-      </>
+    title: 'Remote-Desktop-Zugriff',
+    icon: (
+      <img
+        src={require('@site/static/img/undraw_docusaurus_mountain.svg').default}
+        className={styles.featureSvg}
+        alt="Remote Desktop"
+      />
     ),
+    description: <>Greife von überall auf deinen Linux-PC zu und erhalte das Bild nahezu in Echtzeit.</>,
   },
   {
-    title: 'Documentation',
-    Svg: require('@site/static/img/undraw_docusaurus_tree.svg').default,
-    description: (
-      <>
-        ESN_Repo-Template Wiki was build with Docusaurus.
-        Docusaurus lets you focus on your docs, and we&apos;ll do the chores. Go
-        ahead and move your docs into the <code>docs</code> directory.
-      </>
+    title: 'Sichere Peer-to-Peer Verbindung',
+    icon: (
+      <img
+        src={require('@site/static/img/undraw_docusaurus_tree.svg').default}
+        className={styles.featureSvg}
+        alt="Sichere Verbindung"
+      />
     ),
+    description: <>SmolDesk verbindet die Geräte direkt miteinander. Signaling läuft verschlüsselt.</>,
   },
   {
-    title: 'Powered by React',
-    Svg: require('@site/static/img/undraw_docusaurus_react.svg').default,
-    description: (
-      <>
-        Extend or customize your website layout by reusing React. Docusaurus can
-        be extended while reusing the same header and footer.
-      </>
+    title: 'Mobile-optimierte Oberfläche',
+    icon: (
+      <img
+        src={require('@site/static/img/undraw_docusaurus_react.svg').default}
+        className={styles.featureSvg}
+        alt="Mobile Oberfläche"
+      />
     ),
+    description: <>An kleine Bildschirme angepasst und mit Gestensteuerung sowie Darkmode ausgestattet.</>,
+  },
+  {
+    title: 'Plattformübergreifend',
+    icon: (
+      <img
+        src={require('@site/static/img/undraw_docusaurus_tree.svg').default}
+        className={styles.featureSvg}
+        alt="Plattformübergreifend"
+      />
+    ),
+    description: <>Nutze SmolDesk unter Linux und Android. Eine iOS-Version ist in Planung.</>,
+  },
+  {
+    title: 'Modular erweiterbar',
+    icon: (
+      <img
+        src={require('@site/static/img/undraw_docusaurus_mountain.svg').default}
+        className={styles.featureSvg}
+        alt="Modular"
+      />
+    ),
+    description: <>Funktionen lassen sich über optionale Module jederzeit ergänzen.</>,
   },
 ];
 
-function Feature({title, Svg, description}: FeatureItem) {
+function Feature({title, icon, description}: FeatureItem) {
   return (
     <div className={clsx('col col--4')}>
       <div className="text--center">
-        <Svg className={styles.featureSvg} role="img" />
+        {icon}
       </div>
       <div className="text--center padding-horiz--md">
         <Heading as="h3">{title}</Heading>


### PR DESCRIPTION
## Summary
- update HomepageFeatures component with SmolDesk feature cards
- document HomepageFeatures usage in docs-styleguide

## Testing
- `python3 scripts/docs_validation.py`
- `npx markdownlint-cli docs/**/*.md` *(fails: many warnings)*
- `npm --prefix docs run typecheck` *(fails: missing deps)*
- `npm --prefix docs run build` *(fails: docusaurus not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d485d8ce48324a2b85ad09568d607